### PR TITLE
feat: use journal for write and read dagger client logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# project directories
+build/

--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -2,12 +2,13 @@ package build
 
 import (
 	"context"
-	"os"
+	"fmt"
 
 	"dagger.io/dagger"
 
 	"github.com/spf13/cobra"
 
+	"github.com/aweris/gale/journal"
 	"github.com/aweris/gale/runner"
 )
 
@@ -29,11 +30,26 @@ func build() error {
 	// Create a context to pass to Dagger.
 	ctx := context.Background()
 
+	journalW, journalR := journal.Pipe()
+
+	// Just print the same log to stdout for now. We'll replace this with something interesting later.
+	go func() {
+		for {
+			entry, ok := journalR.ReadEntry()
+			if !ok {
+				break
+			}
+
+			fmt.Println(entry)
+		}
+	}()
+
 	// Connect to Dagger
-	client, clientErr := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	client, clientErr := dagger.Connect(ctx, dagger.WithLogOutput(journalW))
 	if clientErr != nil {
 		return clientErr
 	}
+	defer client.Close()
 
 	_, err := runner.NewBuilder(client).Build(ctx)
 	if err != nil {

--- a/journal/entry.go
+++ b/journal/entry.go
@@ -1,0 +1,103 @@
+package journal
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// EntryType is the type of a journal entry
+type EntryType string
+
+const (
+	// EntryTypeInternal is a log entry from dagger itself , not from the container execution.
+	EntryTypeInternal EntryType = "internal"
+
+	// EntryTypeExecution is a log entry from the container execution.
+	EntryTypeExecution EntryType = "execution"
+
+	// EntryTypeDone is a log entry notifying that the container execution is done for the given index.
+	EntryTypeDone EntryType = "done"
+)
+
+// Entry is a single log entry from the journal
+type Entry struct {
+	Raw        string
+	ID         int
+	Index      int
+	Type       EntryType
+	ElapsedTme time.Duration
+	Message    string
+}
+
+func (e *Entry) String() string {
+	return e.Raw
+}
+
+func parseEntry(id int, line string) *Entry {
+	// Create a new entry with the raw log line and the ID. We'll fill in the rest later.
+	entry := &Entry{Raw: line, ID: id}
+
+	var (
+		index   int
+		info    string
+		message string
+	)
+
+	// Log lines are space-delimited, so split the line into parts
+	//
+	// Our assumptions are:
+	// - Message format is <index> <info> <message>
+	// - The index is always an integer prefixed with a #
+	// - The info is could be a float or a string. If it's a float, it's the elapsed time. Otherwise, it's part of the message or standalone info.
+	// - The message is the rest of the line
+	// - The info and message are optional
+	parts := strings.Split(line, " ")
+
+	// TODO: assume we'll be dealing with valid log lines for now. Make this more robust later.
+	index, _ = strconv.Atoi(strings.TrimPrefix(parts[0], "#"))
+
+	if len(parts) > 1 {
+		info = strings.TrimSpace(parts[1])
+
+		if len(parts) > 2 {
+			message = strings.TrimSpace(strings.Join(parts[2:], " "))
+		}
+	}
+
+	// If the info is a float, it's an execution log with an elapsed time
+	// Example:	#3 0.217 ::debug::ref = 'undefined'
+	if elapsed, err := strconv.ParseFloat(info, 64); err == nil {
+		// The info is a float, which means it's an execution log
+		entry.Index = index
+		entry.Type = EntryTypeExecution
+		entry.ElapsedTme = time.Duration(int64(elapsed * float64(time.Second)))
+		entry.Message = message
+
+		return entry
+	}
+
+	// If the info is "DONE", it's a log notifying that index group is done
+	// Example: #1 DONE 0.0s
+	if info == "DONE" {
+		// The index group is done, and the next info is the total elapsed time as duration string
+		duration, _ := time.ParseDuration(strings.TrimSpace(message))
+
+		entry.Index = index
+		entry.Type = EntryTypeDone
+		entry.ElapsedTme = duration
+
+		return entry
+	}
+
+	// The info is alphanumeric, which means it's an internal log
+	// Example:
+	// 	#1
+	// 	#3 CACHED
+	// 	#5 host.directory /home/aweris/.local/share/gale/ubuntu-latest
+	entry.Index = index
+	entry.Type = EntryTypeInternal
+	entry.Message = strings.Join([]string{info, message}, " ")
+
+	return entry
+}

--- a/journal/pipe.go
+++ b/journal/pipe.go
@@ -1,0 +1,92 @@
+package journal
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Writer is an interface for writing to a journal. It is a combination of the io.Writer and io.Closer interfaces.
+// This interface intended to be used by the dagger client to write to the journal.
+type Writer interface {
+	io.Writer
+	io.Closer
+}
+
+// Reader is an interface for reading from a journal.
+type Reader interface {
+	ReadEntry() (*Entry, bool)
+}
+
+var (
+	_ Writer = new(unboundedPipe)
+	_ Reader = new(unboundedPipe)
+)
+
+// unboundedPipe is a simple implementation of the Writer and Reader interfaces.
+type unboundedPipe struct {
+	cond    *sync.Cond
+	counter *atomic.Uint64
+	buffer  []*Entry
+	closed  bool
+}
+
+// Pipe creates a new Writer and Reader pair that can be used to write and read from a journal.
+func Pipe() (Writer, Reader) {
+	pipe := &unboundedPipe{
+		cond:    sync.NewCond(new(sync.Mutex)),
+		counter: &atomic.Uint64{},
+	}
+	return pipe, pipe
+}
+
+func (p *unboundedPipe) Write(data []byte) (n int, err error) {
+	p.cond.L.Lock()
+	defer p.cond.L.Unlock()
+
+	raw := string(data)
+
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+
+	// Loop through each line and process it
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if line == "" {
+			continue
+		}
+
+		p.buffer = append(p.buffer, parseEntry(int(p.counter.Add(1)), line))
+		p.cond.Signal()
+	}
+
+	return len(data), nil
+}
+
+func (p *unboundedPipe) ReadEntry() (*Entry, bool) {
+	p.cond.L.Lock()
+	defer p.cond.L.Unlock()
+
+	for len(p.buffer) == 0 && !p.closed {
+		p.cond.Wait()
+	}
+
+	if len(p.buffer) == 0 && p.closed {
+		return nil, false
+	}
+
+	value := p.buffer[0]
+	p.buffer = p.buffer[1:]
+	return value, true
+}
+
+func (p *unboundedPipe) Close() error {
+	p.cond.L.Lock()
+	defer p.cond.L.Unlock()
+
+	p.closed = true
+	p.cond.Broadcast()
+	return nil
+}


### PR DESCRIPTION
This is the initial step for processing dagger outputs. For now, it's not making any visual changes