### PR TITLE
feat: initial DX for `gale`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,3 +42,4 @@ linters-settings:
           - github.com/spf13/viper
           - github.com/cli/go-gh/v2
           - github.com/Masterminds/semver/v3
+          - github.com/google/uuid

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -115,10 +115,7 @@ func NewCommand() *cobra.Command {
 // TODO: we should find a better way to get the github contexts. This is a temporary solution.
 
 func GetGithubContext() (*model.GithubContext, error) {
-	github, err := model.NewGithubContextFromEnv()
-	if err != nil {
-		return nil, err
-	}
+	github := model.NewGithubContextFromEnv()
 
 	if !github.CI {
 		// user information
@@ -158,7 +155,7 @@ func GetGithubContext() (*model.GithubContext, error) {
 		github.EventName = "push"                                   // TODO: make this configurable, this is for testing purposes
 		github.EventPath = "/home/runner/_temp/workflow/event.json" // TODO: make this configurable or get from runner
 		github.GraphqlURL = "https://api.github.com/graphql"        // TODO: make this configurable for github enterprise
-		github.RetentionDays = 0
+		github.RetentionDays = "0"
 		github.RunID = "1"
 		github.RunNumber = "1"
 		github.RunAttempt = "1"

--- a/internal/model/dagger_context.go
+++ b/internal/model/dagger_context.go
@@ -1,0 +1,32 @@
+package model
+
+import "os"
+
+// DaggerContext represents the dagger engine connection information should be passed to the container
+type DaggerContext struct {
+	RunnerHost string // where the dagger engine is running
+	Session    string // dagger session information
+}
+
+// NewDaggerContextFromEnv creates a new dagger context from environment variables
+func NewDaggerContextFromEnv() *DaggerContext {
+	return &DaggerContext{
+		RunnerHost: os.Getenv("_EXPERIMENTAL_DAGGER_RUNNER_HOST"),
+		Session:    os.Getenv("DAGGER_SESSION"),
+	}
+}
+
+// ToEnv converts the dagger context to environment variables
+func (d *DaggerContext) ToEnv() map[string]string {
+	env := make(map[string]string)
+
+	if d.RunnerHost != "" {
+		env["_EXPERIMENTAL_DAGGER_RUNNER_HOST"] = d.RunnerHost
+	}
+
+	if d.Session != "" {
+		env["DAGGER_SESSION"] = d.Session
+	}
+
+	return env
+}

--- a/internal/model/github_context.go
+++ b/internal/model/github_context.go
@@ -178,9 +178,9 @@ type GithubContext struct {
 }
 
 // NewGithubContextFromEnv creates a new GithubContext from environment variables.
-func NewGithubContextFromEnv() *GithubContext {
+func NewGithubContextFromEnv() GithubContext {
 	//nolint:goconst // keeping "true" here as string makes it easier to read and understand. No need to create a const.
-	return &GithubContext{
+	return GithubContext{
 		CI:                os.Getenv("CI") == "true",
 		Actions:           os.Getenv("GITHUB_ACTIONS") == "true",
 		Action:            os.Getenv("GITHUB_ACTION"),
@@ -221,7 +221,7 @@ func NewGithubContextFromEnv() *GithubContext {
 
 // ToEnv converts the GithubContext to a map of environment variables.
 // More info: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-func (g *GithubContext) ToEnv() map[string]string {
+func (g GithubContext) ToEnv() map[string]string {
 	return map[string]string{
 		"CI":                         strconv.FormatBool(g.CI),
 		"GITHUB_ACTION":              g.Action,

--- a/internal/model/github_context.go
+++ b/internal/model/github_context.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 )
@@ -128,7 +127,7 @@ type GithubContext struct {
 	RepositoryURL string `json:"repositoryUrl"`
 
 	// The number of days that workflow run logs and artifacts are kept.
-	RetentionDays int `json:"retention_days"`
+	RetentionDays string `json:"retention_days"`
 
 	// A unique number for each workflow run within a repository. This number does not change if you re-run
 	// the workflow run.
@@ -179,19 +178,7 @@ type GithubContext struct {
 }
 
 // NewGithubContextFromEnv creates a new GithubContext from environment variables.
-func NewGithubContextFromEnv() (*GithubContext, error) {
-	var (
-		err           error
-		retentionDays int
-	)
-
-	if val := os.Getenv("GITHUB_RETENTION_DAYS"); val != "" {
-		retentionDays, err = strconv.Atoi(val)
-		if err != nil {
-			return nil, fmt.Errorf("GITHUB_RETENTION_DAYS %s is not a valid integer", val)
-		}
-	}
-
+func NewGithubContextFromEnv() *GithubContext {
 	//nolint:goconst // keeping "true" here as string makes it easier to read and understand. No need to create a const.
 	return &GithubContext{
 		CI:                os.Getenv("CI") == "true",
@@ -218,7 +205,7 @@ func NewGithubContextFromEnv() (*GithubContext, error) {
 		RepositoryID:      os.Getenv("GITHUB_REPOSITORY_ID"),
 		RepositoryOwner:   os.Getenv("GITHUB_REPOSITORY_OWNER"),
 		RepositoryOwnerID: os.Getenv("GITHUB_REPOSITORY_OWNER_ID"),
-		RetentionDays:     retentionDays,
+		RetentionDays:     os.Getenv("GITHUB_RETENTION_DAYS"),
 		RunAttempt:        os.Getenv("GITHUB_RUN_ATTEMPT"),
 		RunID:             os.Getenv("GITHUB_RUN_ID"),
 		RunNumber:         os.Getenv("GITHUB_RUN_NUMBER"),
@@ -229,7 +216,7 @@ func NewGithubContextFromEnv() (*GithubContext, error) {
 		WorkflowSHA:       os.Getenv("GITHUB_WORKFLOW_SHA"),
 		Workspace:         os.Getenv("GITHUB_WORKSPACE"),
 		Token:             os.Getenv("GITHUB_TOKEN"),
-	}, nil
+	}
 }
 
 // ToEnv converts the GithubContext to a map of environment variables.
@@ -260,7 +247,7 @@ func (g *GithubContext) ToEnv() map[string]string {
 		"GITHUB_REPOSITORY_ID":       g.RepositoryID,
 		"GITHUB_REPOSITORY_OWNER":    g.RepositoryOwner,
 		"GITHUB_REPOSITORY_OWNER_ID": g.RepositoryOwnerID,
-		"GITHUB_RETENTION_DAYS":      strconv.Itoa(g.RetentionDays),
+		"GITHUB_RETENTION_DAYS":      g.RetentionDays,
 		"GITHUB_RUN_ATTEMPT":         g.RunAttempt,
 		"GITHUB_RUN_ID":              g.RunID,
 		"GITHUB_RUN_NUMBER":          g.RunNumber,

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -1,0 +1,12 @@
+package model
+
+// Job represents a single job in a GitHub Actions workflow
+//
+// See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id
+type Job struct {
+	Name  string            `yaml:"name"`  // Name is the name of the job
+	Env   map[string]string `yaml:"env"`   // Environment is the environment variables used in the workflow
+	Steps []Step            `yaml:"steps"` // Steps is a list of steps
+
+	// TBD -- we'll add more fields here as we need them.
+}

--- a/internal/model/job_config.go
+++ b/internal/model/job_config.go
@@ -1,0 +1,6 @@
+package model
+
+// JobConfig is the configuration for a job to execute with gale.
+type JobConfig struct {
+	Job Job `json:"job"` // job model
+}

--- a/internal/model/workflows.go
+++ b/internal/model/workflows.go
@@ -5,7 +5,8 @@ type Workflows map[string]*Workflow
 
 // Workflow represents a GitHub Actions workflow.
 type Workflow struct {
-	Path string                 `yaml:"-"`    // path is the relative path to the workflow file.
-	Name string                 `yaml:"name"` // Name is the name of the workflow
-	Jobs map[string]interface{} `yaml:"jobs"` // Jobs is the list of jobs in the workflow.
+	Path string            `yaml:"-"`    // path is the relative path to the workflow file.
+	Name string            `yaml:"name"` // Name is the name of the workflow
+	Env  map[string]string `yaml:"env"`  // Environment is the environment variables used in the workflow
+	Jobs map[string]Job    `yaml:"jobs"` // Jobs is the list of jobs in the workflow.
 }

--- a/pkg/gale/configuration.go
+++ b/pkg/gale/configuration.go
@@ -1,0 +1,33 @@
+package gale
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+)
+
+// TODO: move this file contents to gale.go after refactoring all the code
+
+// With is an interface that can be implemented by any type that can be used to configure a dagger container.
+type With interface {
+	// WithContainerFunc is a function that can be used to configure the container. The signature of this function
+	// matches the signature of the dagger.WithContainerFunc type. Intended to be used with the Load function.
+	WithContainerFunc(container *dagger.Container) *dagger.Container
+}
+
+// Load is a helper function that can be used to load configuration into a dagger container in a more readable way.
+func Load[T With](t T) dagger.WithContainerFunc {
+	return t.WithContainerFunc
+}
+
+// fail returns a container that immediately fails with the given error. This useful for forcing a pipeline to fail
+// inside chaining operations.
+func fail(container *dagger.Container, err error) *dagger.Container {
+	// fail the container with the given error
+	container = container.WithExec([]string{"sh", "-c", "echo " + err.Error() + " && exit 1"})
+
+	// forced evaluation of the pipeline to immediately fail
+	container, _ = container.Sync(context.Background())
+
+	return container
+}

--- a/pkg/gale/consts.go
+++ b/pkg/gale/consts.go
@@ -1,0 +1,8 @@
+package gale
+
+import "errors"
+
+var (
+	ErrWorkflowNotFound = errors.New("workflow not found")
+	ErrJobNotFound      = errors.New("job not found")
+)

--- a/pkg/gale/env.go
+++ b/pkg/gale/env.go
@@ -55,6 +55,7 @@ func (e *Env) WithContainerFunc(container *dagger.Container) *dagger.Container {
 	}
 
 	container = container.WithFile("/usr/local/bin/ghx", ghx)
+	container = container.WithEnvVariable("GHX_HOME", "/home/runner/_temp/ghx")
 
 	// services
 

--- a/pkg/gale/env.go
+++ b/pkg/gale/env.go
@@ -1,0 +1,68 @@
+package gale
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"dagger.io/dagger"
+
+	"github.com/aweris/gale/internal/dagger/services"
+	"github.com/aweris/gale/internal/dagger/tools"
+	"github.com/aweris/gale/internal/model"
+)
+
+var _ With = new(Env)
+
+// Env represents gale execution environment
+type Env struct {
+	client *dagger.Client
+
+	// services
+	artifacts *services.ArtifactService
+}
+
+func (g *Gale) Env() *Env {
+	return &Env{client: g.client}
+}
+
+func (e *Env) WithContainerFunc(container *dagger.Container) *dagger.Container {
+	// dagger context
+	dc := model.NewDaggerContextFromEnv()
+
+	for k, v := range dc.ToEnv() {
+		container = container.WithEnvVariable(k, v)
+	}
+
+	// as a fallback, we're loading docker socket from the host.
+	if dc.RunnerHost == "" || dc.Session == "" {
+		// check if DOCKER_HOST should override the default docker socket location
+		hostDockerSocket := "/var/run/docker.sock"
+
+		if dockerHost := os.Getenv("DOCKER_HOST"); strings.HasPrefix(dockerHost, "unix://") {
+			hostDockerSocket = strings.TrimPrefix(dockerHost, "unix://")
+		}
+
+		container = container.WithUnixSocket("/var/run/docker.sock", e.client.Host().UnixSocket(hostDockerSocket))
+	}
+
+	// tools
+
+	ghx, err := tools.Ghx(context.Background(), e.client)
+	if err != nil {
+		fail(container, fmt.Errorf("error getting ghx: %w", err))
+	}
+
+	container = container.WithFile("/usr/local/bin/ghx", ghx)
+
+	// services
+
+	artifactService := services.NewArtifactService(e.client)
+
+	container = container.With(artifactService.ServiceBinding)
+
+	e.artifacts = artifactService // save for later access
+
+	return container
+}

--- a/pkg/gale/exec.go
+++ b/pkg/gale/exec.go
@@ -15,7 +15,7 @@ type ExecResult struct {
 	Container *dagger.Container
 
 	// contexts
-	github *model.GithubContext
+	github model.GithubContext
 
 	// services
 	artifactService *services.ArtifactService

--- a/pkg/gale/gale.go
+++ b/pkg/gale/gale.go
@@ -40,7 +40,7 @@ type Gale struct {
 
 	// contexts
 
-	github *model.GithubContext
+	github model.GithubContext
 
 	// services
 
@@ -156,7 +156,7 @@ func (g *Gale) loadCurrentRepository() *Gale {
 }
 
 // WithGithubContext sets the github and runner contexts for the gale instance.
-func (g *Gale) WithGithubContext(github *model.GithubContext) *Gale {
+func (g *Gale) WithGithubContext(github model.GithubContext) *Gale {
 	return g.WithModifier(func(container *dagger.Container) (*dagger.Container, error) {
 		// keep reference to the github context in the gale instance to be able to access it later on.
 		g.github = github
@@ -253,7 +253,7 @@ func (g *Gale) Container() (container *dagger.Container, err error) {
 
 // TODO: we should find a better way to get the github contexts. This is a temporary solution.
 
-func getInitialGithubContext() (*model.GithubContext, error) {
+func getInitialGithubContext() (model.GithubContext, error) {
 	github := model.NewGithubContextFromEnv()
 
 	// if we're running in github actions, we can get the github context from the environment variables.
@@ -264,7 +264,7 @@ func getInitialGithubContext() (*model.GithubContext, error) {
 	// update user related information
 	user, err := gh.CurrentUser()
 	if err != nil {
-		return nil, err
+		return model.GithubContext{}, err
 	}
 
 	github.Actor = user.Login
@@ -274,7 +274,7 @@ func getInitialGithubContext() (*model.GithubContext, error) {
 	// update repository related information
 	repo, err := gh.CurrentRepository()
 	if err != nil {
-		return nil, err
+		return model.GithubContext{}, err
 	}
 
 	github.Repository = repo.NameWithOwner
@@ -287,7 +287,7 @@ func getInitialGithubContext() (*model.GithubContext, error) {
 	// update token
 	token, err := gh.GetToken()
 	if err != nil {
-		return nil, err
+		return model.GithubContext{}, err
 	}
 
 	github.Token = token

--- a/pkg/gale/job.go
+++ b/pkg/gale/job.go
@@ -1,0 +1,83 @@
+package gale
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+
+	"dagger.io/dagger"
+
+	"github.com/google/uuid"
+
+	"github.com/aweris/gale/internal/model"
+	"github.com/aweris/gale/pkg/repository"
+)
+
+var _ With = new(Job)
+
+// Job is the configuration for a job to execute with gale.
+type Job struct {
+	client *dagger.Client   // dagger client
+	config *model.JobConfig // configuration of the job to execute
+
+	results *dagger.Directory // results directory where all job related files and configurations are stored
+}
+
+func (g *Gale) Job() *Job {
+	return &Job{
+		client: g.client,
+		config: &model.JobConfig{},
+	}
+}
+
+func (j *Job) Load(ctx context.Context, workflow, job string) (*Job, error) {
+	// load all workflows
+	workflows, err := repository.LoadWorkflows(ctx, j.client)
+	if err != nil {
+		return j, err
+	}
+
+	// load workflow
+	wf, ok := workflows[workflow]
+	if !ok {
+		return j, ErrWorkflowNotFound
+	}
+
+	// load job
+	jm, ok := wf.Jobs[job]
+	if !ok {
+		return j, ErrJobNotFound
+	}
+
+	// set job to job config
+	j.config.Job = jm
+
+	// TODO: add rest of the required fields to job config
+
+	return j, nil
+}
+
+func (j *Job) WithContainerFunc(container *dagger.Container) *dagger.Container {
+	data, err := json.Marshal(j.config)
+	if err != nil {
+		fail(container, err)
+	}
+
+	// TODO: look better way to generate run id, uuid is unique but not readable
+
+	runID := uuid.New().String()
+
+	// unique path for the job
+	path := filepath.Join(containerRunnerPath, "runs", runID)
+
+	// create initial directory for the job and mount it to the container
+	dir := j.client.Directory().WithNewFile("config.json", string(data))
+
+	container = container.WithMountedDirectory(path, dir)
+	container = container.WithExec([]string{"ghx", "run", runID})
+
+	// load final directory for the job
+	j.results = container.Directory(path)
+
+	return container
+}

--- a/tools/ghx/cmd/root.go
+++ b/tools/ghx/cmd/root.go
@@ -2,30 +2,88 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 
-	"github.com/spf13/cobra"
+	"dagger.io/dagger"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/aweris/gale/tools/ghx/cmd/run"
 	"github.com/aweris/gale/tools/ghx/cmd/version"
+	"github.com/aweris/gale/tools/ghx/config"
+	"github.com/aweris/gale/tools/ghx/internal/fs"
 )
 
 // NewCommand  creates a new root command.
 func NewCommand() *cobra.Command {
-	return &cobra.Command{
+	var homeDir string
+
+	cmd := &cobra.Command{
 		Use:   "ghx",
 		Short: "Github Actions Executor",
 		Long:  "Github Actions Executor is a helper tool for gale to run workflows locally",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// set home directory
+			if err := fs.EnsureDir(homeDir); err != nil {
+				return err
+			}
+
+			config.SetConfigHome(homeDir)
+
+			// initialize dagger client and set it to config
+			var opts []dagger.ClientOpt
+
+			if os.Getenv("RUNNER_DEBUG") == "1" {
+				opts = append(opts, dagger.WithLogOutput(os.Stdout))
+			}
+
+			client, err := dagger.Connect(cmd.Context(), opts...)
+			if err != nil {
+				return err
+			}
+
+			config.SetClient(client)
+
+			return nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			// Close the client connection when the command is done.
+			return config.Client().Close()
+		},
 	}
+
+	cmd.PersistentFlags().StringVar(&homeDir, "home", "/home/runner/_temp/ghx", "home directory for ghx")
+
+	bindEnv(cmd.Flags().Lookup("home"), "GHX_HOME")
+
+	return cmd
 }
 
 // Execute runs the command.
 func Execute() {
 	rootCmd := NewCommand()
 
+	rootCmd.AddCommand(run.NewCommand())
 	rootCmd.AddCommand(version.NewCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Printf("Error executing command: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+func bindEnv(fn *pflag.Flag, env string) {
+	if fn == nil || fn.Changed {
+		return
+	}
+
+	val := os.Getenv(env)
+
+	if len(val) > 0 {
+		if err := fn.Value.Set(val); err != nil {
+			log.Fatalf("failed to bind env: %v\n", err)
+		}
 	}
 }

--- a/tools/ghx/cmd/run/run.go
+++ b/tools/ghx/cmd/run/run.go
@@ -1,0 +1,38 @@
+package run
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aweris/gale/internal/model"
+	"github.com/aweris/gale/tools/ghx/config"
+	"github.com/aweris/gale/tools/ghx/internal/fs"
+)
+
+// NewCommand  creates a new root command.
+func NewCommand() *cobra.Command {
+
+	// TODO: improve DX here. It expects run-id as the first argument and config file should be stored in a specific location with a specific name
+	return &cobra.Command{
+		Use:   "run <run-id> [flags]",
+		Short: "Runs a job given run id",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runID := args[0]
+
+			var jc *model.JobConfig
+
+			if err := fs.ReadJSONFile(filepath.Join(config.RunDir(runID), "config.json"), &jc); err != nil {
+				return err
+			}
+
+			// TODO: handle execution of job config
+
+			fmt.Printf("Running job %+v\n", jc)
+
+			return nil
+		},
+	}
+}

--- a/tools/ghx/config/config.go
+++ b/tools/ghx/config/config.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"path/filepath"
+
+	"dagger.io/dagger"
+
+	"github.com/aweris/gale/tools/ghx/internal/log"
+)
+
+// cfg is the global configuration for ghx. No other package should access it directly.
+var cfg = config{
+	home:   "/home/runner/_temp/ghx",
+	logger: log.NewLogger(),
+}
+
+// config represents the configuration for ghx.
+type config struct {
+	home   string
+	client *dagger.Client
+	logger *log.Logger
+}
+
+// SetConfigHome sets the home directory for the ghx configuration.
+func SetConfigHome(home string) {
+	cfg.home = home
+}
+
+// SetClient sets the dagger client for the ghx configuration.
+func SetClient(client *dagger.Client) {
+	cfg.client = client
+}
+
+// Home returns the home directory for the ghx configuration.
+func Home() string {
+	return cfg.home
+}
+
+// ActionsDir returns the directory where the actions are stored.
+func ActionsDir() string {
+	return filepath.Join(cfg.home, "actions")
+}
+
+// RunsDir returns the directory where the runs are stored.
+func RunsDir() string {
+	return filepath.Join(cfg.home, "runs")
+}
+
+// RunDir returns the directory where the run with the given ID is stored.
+func RunDir(runID string) string {
+	return filepath.Join(RunsDir(), runID)
+}
+
+func Client() *dagger.Client {
+	return cfg.client
+}
+
+func Logger() *log.Logger {
+	return cfg.logger
+}

--- a/tools/ghx/internal/fs/doc.go
+++ b/tools/ghx/internal/fs/doc.go
@@ -1,0 +1,2 @@
+// Package fs provides filesystem utilities for ghx.
+package fs

--- a/tools/ghx/internal/fs/fs.go
+++ b/tools/ghx/internal/fs/fs.go
@@ -1,0 +1,99 @@
+package fs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Exists checks if the given path exists.
+func Exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+
+	// Path exists
+	if err == nil {
+		return true, nil
+	}
+
+	// Path does not exist
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	// An error occurred while checking the path
+	return false, err
+}
+
+// EnsureDir ensures that the given directory exists under the ghx data home directory.
+func EnsureDir(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return os.MkdirAll(dir, 0755)
+	}
+
+	return nil
+}
+
+// EnsureFile ensures that the given file exists under the ghx data home directory. If the file does not exist, it will
+// be created.
+//
+// To ensure everything is working as expected, the method will also ensure that the directory of the file
+// exists.
+func EnsureFile(file string) error {
+	// just to be sure that the directory exists
+	if err := EnsureDir(filepath.Dir(file)); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		// Create the file if it doesn't exist
+		file, err := os.Create(file)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+	}
+
+	return nil
+}
+
+// WriteFile ensures that the given file exists under the ghx data home directory. If the file does not
+// exist, it will be created and the given content will be written to it.
+//
+// To ensure everything is working as expected, the method will also ensure that the directory of the file
+// exists.
+func WriteFile(file string, content []byte, permissions os.FileMode) error {
+	if err := EnsureFile(file); err != nil {
+		return err
+	}
+
+	if permissions == 0 {
+		permissions = 0600
+	}
+
+	return os.WriteFile(file, content, permissions)
+}
+
+// ReadJSONFile reads the given path as a JSON file under the ghx data home directory and unmarshal it into the given value.
+func ReadJSONFile[T any](file string, val *T) error {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	// if the file is empty, we don't need to do anything
+	if len(data) == 0 {
+		return nil
+	}
+
+	return json.Unmarshal(data, val)
+}
+
+// WriteJSONFile writes the given value to the given path as a JSON file under the ghx data home directory.
+func WriteJSONFile(file string, val interface{}) error {
+	data, err := json.Marshal(val)
+	if err != nil {
+		return err
+	}
+
+	return WriteFile(file, data, 0600)
+}

--- a/tools/ghx/internal/log/log.go
+++ b/tools/ghx/internal/log/log.go
@@ -1,0 +1,115 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	groupStart = "┏ "
+	groupMid   = "┃ "
+	groupEnd   = "┗ "
+
+	LevelDebug  = "debug"
+	LevelWarn   = "warn"
+	LevelErr    = "error"
+	LevelNotice = "notice"
+)
+
+type Logger struct {
+	groups []string
+}
+
+func NewLogger() *Logger {
+	return &Logger{}
+}
+
+func (l *Logger) StartGroup() {
+	l.log(groupStart, "", "")
+	l.groups = append(l.groups, groupMid)
+}
+
+func (l *Logger) EndGroup() {
+	if len(l.groups) > 0 {
+		l.groups = l.groups[:len(l.groups)-1]
+	}
+
+	l.log(groupEnd, "", "")
+}
+
+func (l *Logger) Info(message string) {
+	l.log("", "", message)
+}
+
+func (l *Logger) Infof(message string, keyvals ...interface{}) {
+	l.logf("", message, keyvals...)
+}
+
+func (l *Logger) Debug(message string) {
+	if os.Getenv("RUNNER_DEBUG") == "1" {
+		l.log("", LevelDebug, message)
+	}
+}
+
+func (l *Logger) Debugf(message string, keyvals ...interface{}) {
+	if os.Getenv("RUNNER_DEBUG") == "1" {
+		l.logf(LevelDebug, message, keyvals...)
+	}
+}
+
+func (l *Logger) Warn(message string) {
+	l.log("", LevelWarn, message)
+}
+
+func (l *Logger) Warnf(message string, keyvals ...interface{}) {
+	l.logf(LevelWarn, message, keyvals...)
+}
+
+func (l *Logger) Error(message string) {
+	l.log("", LevelErr, message)
+}
+
+func (l *Logger) Errorf(message string, keyvals ...interface{}) {
+	l.logf(LevelErr, message, keyvals...)
+}
+
+func (l *Logger) Notice(message string) {
+	l.log("", LevelNotice, message)
+}
+
+func (l *Logger) Noticef(message string, keyvals ...interface{}) {
+	l.logf(LevelNotice, message, keyvals...)
+}
+
+func (l *Logger) logf(level, message string, keyvals ...interface{}) {
+	var args []string
+
+	for i := 0; i < len(keyvals); i += 2 {
+		if keyvals[i+1] != "" && keyvals[i+1] != nil {
+			args = append(args, fmt.Sprintf("%s=%v", keyvals[i], keyvals[i+1]))
+		}
+	}
+
+	l.log("", level, fmt.Sprintf("%s %s", message, strings.Join(args, ",")))
+}
+
+func (l *Logger) log(prefix, level, message string) {
+	sb := strings.Builder{}
+
+	if len(l.groups) > 0 {
+		sb.WriteString(strings.Join(l.groups, ""))
+	}
+
+	if prefix != "" {
+		sb.WriteString(prefix)
+	}
+
+	if level != "" {
+		sb.WriteString(fmt.Sprintf("[%s] ", level))
+	}
+
+	sb.WriteString(message)
+
+	fmt.Println(sb.String())
+}


### PR DESCRIPTION
The initial version of the new DX of the `gale`

Introduces: 

- `With` interface that can be implemented by any type that can be used to configure a dagger container.

```golang
type With interface {
	WithContainerFunc(container *dagger.Container) *dagger.Container
}
```

- `gale.Env()` to configure the execution environment

```golang
env := gale.Env()

container = container.With(gale.Load(env)) // configures all tools, services and env values required by `gale`
```

- `gale.Job()` to configure the jobs to execute

```golang
job, err := g.Job().Load(ctx, "example-golangci-lint", "golangci-lint")
if err != nil {
  return err
}

container = container.With(gale.Load(job))
```

An example workflow:

```golang
job, err := g.Job().Load(ctx, "example-golangci-lint", "golangci-lint")
if err != nil {
  return err
}

dagger.Container().
  From(<runner-image>).
  With(gale.Load(gale.Env()).
  With(gale.Load(job)).
  Sync(ctx)
```

Depends on #48 
Related to #45 