### PR TITLE
build: add dev engine

### DIFF
--- a/internal/dagger/tools/ghx.go
+++ b/internal/dagger/tools/ghx.go
@@ -16,11 +16,6 @@ func Ghx(ctx context.Context) (*dagger.File, error) {
 
 	tag := v.GitVersion
 
-	// If the tag is a dev tag, we'll use the main branch.
-	if tag == "v0.0.0-dev" {
-		tag = "main"
-	}
-
 	file := config.Client().Container().From("ghcr.io/aweris/gale/tools/ghx:" + tag).File("/ghx")
 
 	// check, if the file doesn't exist or is empty

--- a/internal/mage/.gitignore
+++ b/internal/mage/.gitignore
@@ -1,0 +1,2 @@
+## Generated Files
+engine.toml

--- a/internal/mage/dev/engine.go
+++ b/internal/mage/dev/engine.go
@@ -1,0 +1,85 @@
+package dev
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+type Engine mg.Namespace
+
+const (
+	RegistryContainerName           = "registry"
+	RegistryContainerPort           = "5000"
+	DaggerEngineContainerNamePrefix = "dagger-engine"
+	DaggerEngineVersion             = "v0.6.4"
+	EngineToml                      = `debug = true
+
+insecure-entitlements = ["security.insecure"]
+
+[registry."docker.io"]
+    mirrors = ["{{.Registry}}"]
+
+[registry."ghcr.io"]
+	mirrors = ["{{.Registry}}"]
+
+[registry."{{.Registry}}"]
+    insecure = true
+    http = true
+`
+)
+
+// Start starts the dagger engine and the registry container with mirroring enabled.
+func (_ Engine) Start() error {
+	mg.Deps(Engine.Clean)
+
+	err := sh.Run("docker", "run", "-d", "--name", RegistryContainerName, "-p", fmt.Sprintf("%s:%s", RegistryContainerPort, RegistryContainerPort), "registry:2")
+	if err != nil {
+		return err
+	}
+
+	ip, err := sh.Output("docker", "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", RegistryContainerName)
+	if err != nil {
+		return err
+	}
+
+	config := strings.ReplaceAll(EngineToml, "{{.Registry}}", fmt.Sprintf("%s:%s", ip, RegistryContainerPort))
+
+	err = os.WriteFile(filepath.Join(os.Getenv("PWD"), "engine.toml"), []byte(config), 0600)
+	if err != nil {
+		return err
+	}
+
+	return sh.Run("docker", "run", "-d", "--name", EngineContainerName(), "-v", fmt.Sprintf("%s:/etc/dagger/engine.toml", filepath.Join(os.Getenv("PWD"), "engine.toml")), "--privileged", fmt.Sprintf("registry.dagger.io/engine:%s", DaggerEngineVersion))
+}
+
+// Env prints the environment variables for running gale with development dagger engine.
+func (_ Engine) Env() error {
+	fmt.Printf("export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://%s\n", EngineContainerName())
+
+	ip, err := sh.Output("docker", "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", RegistryContainerName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("export _GALE_DOCKER_REGISTRY=%s:%s\n", ip, RegistryContainerPort)
+
+	return nil
+}
+
+// Clean force removes registry and dagger engine containers
+func (_ Engine) Clean() error {
+
+	sh.Run("docker", "rm", "-f", RegistryContainerName)
+	sh.Run("docker", "rm", "-f", EngineContainerName())
+
+	return nil
+}
+
+func EngineContainerName() string {
+	return strings.Join([]string{DaggerEngineContainerNamePrefix, DaggerEngineVersion}, "-")
+}

--- a/internal/mage/dev/tools.go
+++ b/internal/mage/dev/tools.go
@@ -1,0 +1,25 @@
+package dev
+
+import (
+	"context"
+	"fmt"
+	"github.com/aweris/gale/internal/version"
+	"os"
+
+	"github.com/aweris/gale/internal/mage/tools"
+	"github.com/magefile/mage/mg"
+)
+
+type Tools mg.Namespace
+
+// Publish publishes dev version of the tool to the local registry.
+func (_ Tools) Publish(ctx context.Context) error {
+	registry := os.Getenv("_GALE_DOCKER_REGISTRY")
+	if registry == "" {
+		return fmt.Errorf("no registry set, please run `mage dev:engine:start` first,than run `eval $(mage dev:engine:env)`")
+	}
+
+	v := version.GetVersion()
+
+	return tools.Ghx{}.Publish(ctx, v.GitVersion)
+}

--- a/internal/mage/magefile.go
+++ b/internal/mage/magefile.go
@@ -3,6 +3,9 @@
 package main
 
 import (
+	//mage:import dev
+	_ "github.com/aweris/gale/internal/mage/dev"
+
 	//mage:import tools
 	_ "github.com/aweris/gale/internal/mage/tools"
 )

--- a/internal/mage/tools/ghx.go
+++ b/internal/mage/tools/ghx.go
@@ -27,6 +27,11 @@ func (_ Ghx) Publish(ctx context.Context, version string) error {
 
 	image := fmt.Sprintf("ghcr.io/aweris/gale/tools/ghx:%s", version)
 
+	// If the registry is set, we'll use that instead of the default one. This is useful for testing and development.
+	if registry := os.Getenv("_GALE_DOCKER_REGISTRY"); registry != "" {
+		image = fmt.Sprintf("%s/aweris/gale/tools/ghx:%s", registry, version)
+	}
+
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	if err != nil {
 		return err


### PR DESCRIPTION
Add new mage targets to help our development process

```
Targets:
  dev:engine:clean     force removes registry and dagger engine containers
  dev:engine:env       prints the environment variables for running gale with development dagger engine.
  dev:engine:start     starts the dagger engine and the registry container with mirroring enabled.
  dev:tools:publish    publishes dev version of the tool to the local registry.
  tools:ghx:publish    publishes the artifact service to ghcr.io/aweris/gale/services/artifact with the given version.
  ```