### PR TITLE
fix: use ref_name for version

### DIFF
--- a/.github/workflows/release-main.yaml
+++ b/.github/workflows/release-main.yaml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish artifact-service
-        run: ./hack/mage tools:ghx:publish main
+        run: ./hack/mage tools:ghx:publish ${{ github.ref_name }}
 
   artifact-service:
     runs-on: ubuntu-latest
@@ -48,4 +48,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish artifact-service
-        run: ./hack/mage services:artifact:publish main
+        run: ./hack/mage services:artifact:publish ${{ github.ref_name }}

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -46,7 +46,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish artifact-service
-        run: ./hack/mage tools:ghx:publish ${{ github.ref }}
+        run: ./hack/mage tools:ghx:publish ${{ github.ref_name }}
 
   artifact-service:
     runs-on: ubuntu-latest
@@ -67,4 +67,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish artifact-service
-        run: ./hack/mage services:artifact:publish ${{ github.ref }}
+        run: ./hack/mage services:artifact:publish ${{ github.ref_name }}


### PR DESCRIPTION
`github.ref` is returns the fully-formed ref however we need short version of it. 