### PR TITLE
fix broken runner image

### DIFF
--- a/internal/dagger/images/images.go
+++ b/internal/dagger/images/images.go
@@ -11,14 +11,12 @@ import (
 
 // RunnerBase returns a container with the base image for the runner.
 func RunnerBase() *dagger.Container {
-	return config.Client().Container().
-		Pipeline("Runner Base Image").
-		From("ghcr.io/catthehacker/ubuntu:act-22.04")
+	// original image is ghcr.io/catthehacker/ubuntu:act-latest-20230801. moved to ghcr.io/aweris/gale/runner/ubuntu:22.04
+	// to work around issues similar to https://github.com/catthehacker/docker_images/issues/102
+	return config.Client().Container().From("ghcr.io/aweris/gale/runner/ubuntu:22.04")
 }
 
 // GoBase returns a container with the base image for the go
 func GoBase() *dagger.Container {
-	return config.Client().Container().
-		Pipeline("Go Base Image").
-		From("golang:" + strings.TrimPrefix(runtime.Version(), "go"))
+	return config.Client().Container().From("golang:" + strings.TrimPrefix(runtime.Version(), "go"))
 }


### PR DESCRIPTION
Fixes issue: https://github.com/catthehacker/docker_images/issues/102 by cloning `ghcr.io/catthehacker/ubuntu:act-latest-20230801` image under gale repository.

This is a short-term solution. We still need to address this issue later. 