### PR TITLE
fix: use local git to find git sha

### DIFF
--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -158,11 +158,11 @@ type GithubWorkflowContext struct {
 }
 
 // NewGithubWorkflowContext creates a new GithubWorkflowContext from the given workflow.
-func NewGithubWorkflowContext(repo *Repository, workflow *Workflow, runID string) GithubWorkflowContext {
+func NewGithubWorkflowContext(repo *Repository, workflow *Workflow, runID, workflowSHA string) GithubWorkflowContext {
 	return GithubWorkflowContext{
 		Workflow:      workflow.Name,
 		WorkflowRef:   fmt.Sprintf("%s/%s@%s", repo.NameWithOwner, workflow.Path, repo.CurrentRef),
-		WorkflowSHA:   workflow.SHA,
+		WorkflowSHA:   workflowSHA,
 		RunID:         runID,
 		RunNumber:     "1", // TODO: fill this value
 		RunAttempt:    "1", // TODO: fill this value

--- a/internal/core/repository.go
+++ b/internal/core/repository.go
@@ -178,16 +178,5 @@ func (r *Repository) loadWorkflow(ctx context.Context, path string, file *dagger
 		workflow.Name = path
 	}
 
-	// TODO: this is an expensive operation. We should move this to a separate method and call it only when needed.
-
-	api := fmt.Sprintf("repos/%s/contents/%s?ref=%s", r.NameWithOwner, path, r.CurrentRef)
-
-	stdout, stderr, err := gh.Exec("api", api, "--jq", ".sha")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current repository: %w stderr: %s", err, stderr.String())
-	}
-
-	workflow.SHA = strings.TrimSpace(stdout.String())
-
 	return &workflow, nil
 }

--- a/internal/core/workflow.go
+++ b/internal/core/workflow.go
@@ -8,7 +8,6 @@ type Workflow struct {
 	Name string            `yaml:"name"` // Name is the name of the workflow.
 	Env  map[string]string `yaml:"env"`  // Env is the environment variables used in the workflow
 	Jobs map[string]Job    `yaml:"jobs"` // Jobs is the list of jobs in the workflow.
-	SHA  string            `yaml:"-"`    // SHA is the commit SHA for the workflow file. Set by gale when loading the workflow.
 
 	// TBD: add more fields when needed
 }


### PR DESCRIPTION
Not all files and commits exist remotely. Use local git to look for commit sha