### PR TITLE
refactor: remove commit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,9 @@ Since `dagger run` is an optional command, it's omitted in the example above. So
 
 For commands described above all parameters are optional. Available command flags for `list` and `run` commands are:
 ```
-  --branch string          branch to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.
-  --commit string          commit to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.
   --repo string            owner/repo to load workflows from. If empty, repository information of the current directory will be used.
-  --tag string             tag to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.
+  --branch string          branch to load workflows from. Only one of branch or tag can be used. Precedence is as follows: tag, branch.
+  --tag string             tag to load workflows from. Only one of branch or tag can be used. Precedence is as follows: tag, branch.
   --workflows-dir string   directory to load workflows from. If empty, workflows will be loaded from the default directory.
 ```
 

--- a/cmd/gale/list/list.go
+++ b/cmd/gale/list/list.go
@@ -73,9 +73,8 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo to load workflows from. If empty, repository information of the current directory will be used.")
-	cmd.Flags().StringVar(&getOpts.Branch, "branch", "", "branch to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.")
-	cmd.Flags().StringVar(&getOpts.Tag, "tag", "", "tag to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.")
-	cmd.Flags().StringVar(&getOpts.Commit, "commit", "", "commit to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.")
+	cmd.Flags().StringVar(&getOpts.Branch, "branch", "", "branch to load workflows from. Only one of branch or tag can be used. Precedence is as follows: tag, branch.")
+	cmd.Flags().StringVar(&getOpts.Tag, "tag", "", "tag to load workflows from. Only one of branch or tag can be used. Precedence is as follows: tag, branch.")
 	cmd.Flags().StringVar(&loadOpts.WorkflowsDir, "workflows-dir", "", "directory to load workflows from. If empty, workflows will be loaded from the default directory.")
 
 	return cmd

--- a/cmd/gale/run/run.go
+++ b/cmd/gale/run/run.go
@@ -49,9 +49,8 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.Repo, "repo", "", "owner/repo to load workflows from. If empty, repository information of the current directory will be used.")
-	cmd.Flags().StringVar(&opts.Branch, "branch", "", "branch to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.")
-	cmd.Flags().StringVar(&opts.Tag, "tag", "", "tag to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.")
-	cmd.Flags().StringVar(&opts.Commit, "commit", "", "commit to load workflows from. Only one of branch, tag or commit can be used. Precedence is as follows: commit, tag, branch.")
+	cmd.Flags().StringVar(&opts.Branch, "branch", "", "branch to load workflows from. Only one of branch or tag can be used. Precedence is as follows: tag, branch.")
+	cmd.Flags().StringVar(&opts.Tag, "tag", "", "tag to load workflows from. Only one of branch or tag can be used. Precedence is as follows: tag, branch.")
 	cmd.Flags().StringVar(&opts.WorkflowsDir, "workflows-dir", "", "directory to load workflows from. If empty, workflows will be loaded from the default directory.")
 	cmd.Flags().StringToStringVar(&opts.Secrets, "secret", nil, "secrets to be used in the workflow. Format: --secret name=value")
 

--- a/internal/core/repository.go
+++ b/internal/core/repository.go
@@ -46,11 +46,10 @@ type RepositoryBranchRef struct {
 // If none of the options are set, the default branch will be used. Default branch or remote repositories is configured
 // in the GitHub repository settings. For local repositories, it's the branch that is currently checked out.
 //
-// If multiple options are set, the precedence is as follows: commit, tag, branch.
+// If multiple options are set, the precedence is as follows: tag, branch.
 type GetRepositoryOpts struct {
 	Branch string
 	Tag    string
-	Commit string
 }
 
 // GetCurrentRepository returns current repository information. This is a wrapper around GetRepository with empty name.
@@ -86,9 +85,6 @@ func GetRepository(name string, opts ...GetRepositoryOpts) (*Repository, error) 
 
 	// load repo tree based on the options precedence
 	switch {
-	case opt.Commit != "":
-		dir = git.Commit(opt.Commit).Tree()
-
 	case opt.Tag != "":
 		dir = git.Tag(opt.Tag).Tree()
 		ref = fmt.Sprintf("refs/tags/%s", opt.Tag)

--- a/pkg/gale/gale.go
+++ b/pkg/gale/gale.go
@@ -19,7 +19,6 @@ type RunOpts struct {
 	Repo         string
 	Branch       string
 	Tag          string
-	Commit       string
 	WorkflowsDir string
 	Secrets      map[string]string
 }
@@ -32,7 +31,7 @@ func Run(ctx context.Context, workflow, job string, opts ...RunOpts) dagger.With
 			opt = opts[0]
 		}
 
-		repo, err := core.GetRepository(opt.Repo, core.GetRepositoryOpts{Branch: opt.Branch, Tag: opt.Tag, Commit: opt.Commit})
+		repo, err := core.GetRepository(opt.Repo, core.GetRepositoryOpts{Branch: opt.Branch, Tag: opt.Tag})
 		if err != nil {
 			return helpers.FailPipeline(container, err)
 		}


### PR DESCRIPTION
Remove the `--commit` option from `gale` as it is not compatible with `Github Actions` and adds unnecessary complexity. We can always add it back later.