### PR TITLE
fix: extend shell support for run steps

### DIFF
--- a/ci/workflows/step-run.yaml
+++ b/ci/workflows/step-run.yaml
@@ -1,0 +1,25 @@
+name: shell
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Default Shell
+        run: echo "Hello World"
+
+      - name: Bash Shell
+        shell: bash
+        run: echo "Hello World"
+
+      - name: Python Shell
+        shell: python
+        run: print("Hello World")
+
+      - name: SH Shell
+        shell: sh
+        run: echo "Hello World"

--- a/tools/ghx/runner/cmd_executor.go
+++ b/tools/ghx/runner/cmd_executor.go
@@ -69,7 +69,6 @@ func NewCmdExecutorFromStepRun(sr *StepRun) *CmdExecutor {
 	args := []string{sr.Shell}
 
 	args = append(args, sr.ShellArgs...)
-	args = append(args, sr.Path)
 
 	env := make(map[string]string)
 


### PR DESCRIPTION
PR introduces support for shell types:

- bash
- sh
- python
