### PR TITLE
feat: extend preflight checks

### DIFF
--- a/pkg/preflight/task.go
+++ b/pkg/preflight/task.go
@@ -18,12 +18,13 @@ type Task interface {
 
 // Task names to make it easier to reference them in dependencies.
 const (
-	NameDaggerCheck       = "Dagger"
-	NameGHCheck           = "GitHub CLI"
-	NameRepoLoader        = "Repo"
-	NameWorkflowLoader    = "Workflow"
-	NameDockerImagesCheck = "Docker Images"
-	NameStepShellCheck    = "Run Step Shell"
+	NameDaggerCheck             = "Dagger"
+	NameGHCheck                 = "GitHub CLI"
+	NameRepoLoader              = "Repo"
+	NameWorkflowLoader          = "Workflow"
+	NameDockerImagesCheck       = "Docker Images"
+	NameStepShellCheck          = "Run Step Shell"
+	NameMissingExprContextCheck = "Missing Expression Context"
 )
 
 // StandardTasks returns the standard tasks that are used in preflight checks.
@@ -35,5 +36,6 @@ func StandardTasks() []Task {
 		new(WorkflowLoader),
 		new(DockerImagesCheck),
 		new(StepShellCheck),
+		new(MissingExprContextCheck),
 	}
 }

--- a/pkg/preflight/task.go
+++ b/pkg/preflight/task.go
@@ -22,6 +22,7 @@ const (
 	NameGHCheck        = "GitHub CLI"
 	NameRepoLoader     = "Repo"
 	NameWorkflowLoader = "Workflow"
+	NameStepShellCheck = "Run Step Shell"
 )
 
 // StandardTasks returns the standard tasks that are used in preflight checks.
@@ -31,5 +32,6 @@ func StandardTasks() []Task {
 		new(GHCheck),
 		new(RepoLoader),
 		new(WorkflowLoader),
+		new(StepShellCheck),
 	}
 }

--- a/pkg/preflight/task.go
+++ b/pkg/preflight/task.go
@@ -18,11 +18,12 @@ type Task interface {
 
 // Task names to make it easier to reference them in dependencies.
 const (
-	NameDaggerCheck    = "Dagger"
-	NameGHCheck        = "GitHub CLI"
-	NameRepoLoader     = "Repo"
-	NameWorkflowLoader = "Workflow"
-	NameStepShellCheck = "Run Step Shell"
+	NameDaggerCheck       = "Dagger"
+	NameGHCheck           = "GitHub CLI"
+	NameRepoLoader        = "Repo"
+	NameWorkflowLoader    = "Workflow"
+	NameDockerImagesCheck = "Docker Images"
+	NameStepShellCheck    = "Run Step Shell"
 )
 
 // StandardTasks returns the standard tasks that are used in preflight checks.
@@ -32,6 +33,7 @@ func StandardTasks() []Task {
 		new(GHCheck),
 		new(RepoLoader),
 		new(WorkflowLoader),
+		new(DockerImagesCheck),
 		new(StepShellCheck),
 	}
 }

--- a/pkg/preflight/task.go
+++ b/pkg/preflight/task.go
@@ -25,6 +25,7 @@ const (
 	NameDockerImagesCheck       = "Docker Images"
 	NameStepShellCheck          = "Run Step Shell"
 	NameMissingExprContextCheck = "Missing Expression Context"
+	NameStepActionCheck         = "Step Action"
 )
 
 // StandardTasks returns the standard tasks that are used in preflight checks.
@@ -36,6 +37,7 @@ func StandardTasks() []Task {
 		new(WorkflowLoader),
 		new(DockerImagesCheck),
 		new(StepShellCheck),
+		new(StepActionCheck),
 		new(MissingExprContextCheck),
 	}
 }

--- a/pkg/preflight/task_docker_images.go
+++ b/pkg/preflight/task_docker_images.go
@@ -25,11 +25,9 @@ func (d *DockerImagesCheck) DependsOn() []string {
 
 func (d *DockerImagesCheck) Run(ctx *Context, _ Options) Result {
 	var (
-		msg []Message
-
 		status = Passed
+		msg    = make([]Message, 0)
 	)
-
 	// validate runner image
 	_, err := config.Client().Container().From(config.RunnerImage()).Sync(ctx.Context)
 	if err != nil {
@@ -39,7 +37,7 @@ func (d *DockerImagesCheck) Run(ctx *Context, _ Options) Result {
 		msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Runner image %s is available", config.RunnerImage())})
 	}
 
-	for image, _ := range ctx.DockerImages {
+	for image := range ctx.DockerImages {
 		_, err := config.Client().Container().From(image).Sync(ctx.Context)
 		if err != nil {
 			status = Failed

--- a/pkg/preflight/task_docker_images.go
+++ b/pkg/preflight/task_docker_images.go
@@ -1,0 +1,57 @@
+package preflight
+
+import (
+	"fmt"
+
+	"github.com/aweris/gale/internal/config"
+)
+
+var _ Task = new(DockerImagesCheck)
+
+// DockerImagesCheck is a preflight check that checks if all docker images are available.
+type DockerImagesCheck struct{}
+
+func (d *DockerImagesCheck) Name() string {
+	return NameDockerImagesCheck
+}
+
+func (d *DockerImagesCheck) Type() TaskType {
+	return TaskTypeCheck
+}
+
+func (d *DockerImagesCheck) DependsOn() []string {
+	return []string{NameDaggerCheck, NameWorkflowLoader}
+}
+
+func (d *DockerImagesCheck) Run(ctx *Context, _ Options) Result {
+	var (
+		msg []Message
+
+		status = Passed
+	)
+
+	// validate runner image
+	_, err := config.Client().Container().From(config.RunnerImage()).Sync(ctx.Context)
+	if err != nil {
+		status = Failed
+		msg = append(msg, Message{Level: Error, Content: fmt.Sprintf("Runner image %s is not available", config.RunnerImage())})
+	} else {
+		msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Runner image %s is available", config.RunnerImage())})
+	}
+
+	for image, _ := range ctx.DockerImages {
+		_, err := config.Client().Container().From(image).Sync(ctx.Context)
+		if err != nil {
+			status = Failed
+			msg = append(msg, Message{Level: Error, Content: fmt.Sprintf("Docker image %s is not available", image)})
+		} else {
+			msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Docker image %s is available", image)})
+		}
+	}
+
+	if status == Passed {
+		msg = append(msg, Message{Level: Info, Content: "All docker images are available"})
+	}
+
+	return Result{Status: status, Messages: msg}
+}

--- a/pkg/preflight/task_missing_expr_context.go
+++ b/pkg/preflight/task_missing_expr_context.go
@@ -22,11 +22,10 @@ func (m *MissingExprContextCheck) DependsOn() []string {
 	return []string{NameDaggerCheck, NameWorkflowLoader}
 }
 
-func (m *MissingExprContextCheck) Run(ctx *Context, opt Options) Result {
+func (m *MissingExprContextCheck) Run(ctx *Context, _ Options) Result {
 	var (
-		msg []Message
-
 		status = Passed
+		msg    = make([]Message, 0)
 	)
 
 	data, err := ctx.Repo.GitRef.Dir.File(ctx.Workflow.Path).Contents(ctx.Context)
@@ -43,7 +42,7 @@ func (m *MissingExprContextCheck) Run(ctx *Context, opt Options) Result {
 		return Result{
 			Status: Failed,
 			Messages: []Message{
-				{Level: Error, Content: fmt.Sprintf("Workflow file is empty")},
+				{Level: Error, Content: "Workflow file is empty"},
 			},
 		}
 	}

--- a/pkg/preflight/task_missing_expr_context.go
+++ b/pkg/preflight/task_missing_expr_context.go
@@ -1,0 +1,60 @@
+package preflight
+
+import (
+	"fmt"
+	"strings"
+)
+
+var _ Task = new(MissingExprContextCheck)
+
+// MissingExprContextCheck is a preflight check that checks if there is any missing expression context.
+type MissingExprContextCheck struct{}
+
+func (m *MissingExprContextCheck) Name() string {
+	return NameMissingExprContextCheck
+}
+
+func (m *MissingExprContextCheck) Type() TaskType {
+	return TaskTypeCheck
+}
+
+func (m *MissingExprContextCheck) DependsOn() []string {
+	return []string{NameDaggerCheck, NameWorkflowLoader}
+}
+
+func (m *MissingExprContextCheck) Run(ctx *Context, opt Options) Result {
+	var (
+		msg []Message
+
+		status = Passed
+	)
+
+	data, err := ctx.Repo.GitRef.Dir.File(ctx.Workflow.Path).Contents(ctx.Context)
+	if err != nil {
+		return Result{
+			Status: Failed,
+			Messages: []Message{
+				{Level: Error, Content: fmt.Sprintf("Load workflow file failed: %s", err.Error())},
+			},
+		}
+	}
+
+	if data == "" {
+		return Result{
+			Status: Failed,
+			Messages: []Message{
+				{Level: Error, Content: fmt.Sprintf("Workflow file is empty")},
+			},
+		}
+	}
+
+	// TODO: look better way other than hard-coding the list of not supported expression contexts.
+
+	for _, context := range []string{"env", "vars", "strategy", "matrix", "needs", "jobs"} {
+		if strings.Contains(data, fmt.Sprintf("${{ %s.", context)) {
+			msg = append(msg, Message{Level: Warning, Content: fmt.Sprintf("Workflow file %s contains not supported expression context %s. This may cause unexpected behavior", ctx.Workflow.Path, context)})
+		}
+	}
+
+	return Result{Status: status, Messages: msg}
+}

--- a/pkg/preflight/task_step_custom_action.go
+++ b/pkg/preflight/task_step_custom_action.go
@@ -1,0 +1,84 @@
+package preflight
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aweris/gale/internal/config"
+	"github.com/aweris/gale/internal/core"
+)
+
+var _ Task = new(StepActionCheck)
+
+// StepActionCheck is a preflight check that checks related to step action.
+type StepActionCheck struct{}
+
+func (s *StepActionCheck) Name() string {
+	return NameStepActionCheck
+}
+
+func (s *StepActionCheck) Type() TaskType {
+	return TaskTypeCheck
+}
+
+func (s *StepActionCheck) DependsOn() []string {
+	return []string{NameDaggerCheck, NameWorkflowLoader}
+}
+
+func (s *StepActionCheck) Run(ctx *Context, _ Options) Result {
+	var (
+		msg []Message
+
+		status    = Passed
+		checkNode = false
+	)
+
+	// runner container
+	runner := config.Client().Container().From(config.RunnerImage())
+
+	for uses, action := range ctx.CustomActions {
+		if action.Meta.Runs.Using == core.ActionRunsUsingComposite {
+			status = Failed
+			msg = append(msg, Message{Level: Error, Content: fmt.Sprintf("Action %s is is a composite action. Composite actions are not supported", uses)})
+			continue
+		}
+
+		if action.Meta.Runs.Using == core.ActionRunsUsingNode12 || action.Meta.Runs.Using == core.ActionRunsUsingNode16 {
+			checkNode = true
+		}
+	}
+
+	if checkNode {
+		out, err := runner.WithExec([]string{"which", "node"}).Stdout(ctx.Context)
+
+		// ignore the error since we will check the output, not the error. This check just to ensure we'll not hide
+		// any error.
+		if err != nil {
+			msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Check node returned error: %s", err.Error())})
+		}
+
+		// trim the output and remove the new line character
+		out = strings.TrimSpace(strings.TrimSuffix(out, "\n"))
+
+		// if the output is empty or contains not found message then the shell is not available
+		if out == "" || out == fmt.Sprintf("node not found") {
+			status = Failed
+			msg = append(msg, Message{Level: Error, Content: fmt.Sprintf("Node is not available in the runner image")})
+		} else {
+			msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Node is available in the runner image")})
+
+			version, err := runner.WithExec([]string{"node", "--version"}).Stdout(ctx.Context)
+
+			// trim the output and remove the new line character
+			version = strings.TrimSpace(strings.TrimSuffix(version, "\n"))
+
+			if err != nil {
+				msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Check node version returned error: %s", err.Error())})
+			} else {
+				msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Node version is %s", version)})
+			}
+		}
+	}
+
+	return Result{Status: status, Messages: msg}
+}

--- a/pkg/preflight/task_step_custom_action.go
+++ b/pkg/preflight/task_step_custom_action.go
@@ -27,10 +27,9 @@ func (s *StepActionCheck) DependsOn() []string {
 
 func (s *StepActionCheck) Run(ctx *Context, _ Options) Result {
 	var (
-		msg []Message
-
 		status    = Passed
 		checkNode = false
+		msg       = make([]Message, 0)
 	)
 
 	// runner container
@@ -61,11 +60,11 @@ func (s *StepActionCheck) Run(ctx *Context, _ Options) Result {
 		out = strings.TrimSpace(strings.TrimSuffix(out, "\n"))
 
 		// if the output is empty or contains not found message then the shell is not available
-		if out == "" || out == fmt.Sprintf("node not found") {
+		if out == "" || out == "node not found" {
 			status = Failed
-			msg = append(msg, Message{Level: Error, Content: fmt.Sprintf("Node is not available in the runner image")})
+			msg = append(msg, Message{Level: Error, Content: "Node is not available in the runner image"})
 		} else {
-			msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Node is available in the runner image")})
+			msg = append(msg, Message{Level: Debug, Content: "Node is available in the runner image"})
 
 			version, err := runner.WithExec([]string{"node", "--version"}).Stdout(ctx.Context)
 

--- a/pkg/preflight/task_supported_shells.go
+++ b/pkg/preflight/task_supported_shells.go
@@ -1,0 +1,77 @@
+package preflight
+
+import (
+	"fmt"
+	"github.com/aweris/gale/internal/config"
+	"strings"
+)
+
+var _ Task = new(StepShellCheck)
+
+// StepShellCheck is a preflight check that checks if step shell is supported.
+type StepShellCheck struct{}
+
+func (s *StepShellCheck) Name() string {
+	return NameStepShellCheck
+}
+
+func (s *StepShellCheck) Type() TaskType {
+	return TaskTypeCheck
+}
+
+func (s *StepShellCheck) DependsOn() []string {
+	return []string{NameWorkflowLoader}
+}
+
+func (s *StepShellCheck) Run(ctx *Context, _ Options) Result {
+	var (
+		msg []Message
+
+		status = Passed
+	)
+
+	// TODO: look better way other than hard-coding the list of not supported shells.
+
+	// list of not supported shells. This list will be updated when a new shell is supported.
+	notSupportedShells := map[string]bool{
+		"pwsh":       true,
+		"powershell": true,
+		"cmd":        true,
+	}
+
+	// runner container
+	runner := config.Client().Container().From(config.RunnerImage())
+
+	for shell, _ := range ctx.Shells {
+		if _, ok := notSupportedShells[shell]; ok {
+			status = Failed
+			msg = append(msg, Message{Level: Error, Content: fmt.Sprintf("Shell %s is not supported", shell)})
+			continue
+		}
+
+		// TODO: not sure if this is the best way to check if a shell is available in the runner image.
+		//  however, this will work for current runner image.
+
+		// check if we can execute a container with given dagger context exist in environment
+		out, err := runner.WithExec([]string{"which", shell}).Stdout(ctx.Context)
+		// ignore the error since we will check the output, not the error. This check just to ensure we'll not hide
+		// any error.
+		if err != nil {
+			msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Check shell %s returned error: %s", shell, err.Error())})
+		}
+
+		// trim the output and remove the new line character
+		out = strings.TrimSpace(strings.TrimSuffix(out, "\n"))
+
+		// if the output is empty or contains not found message then the shell is not available
+		if out == "" || out == fmt.Sprintf("%s not found", shell) {
+			status = Failed
+			msg = append(msg, Message{Level: Error, Content: fmt.Sprintf("Shell %s is not available in the runner image", shell)})
+			continue
+		}
+
+		msg = append(msg, Message{Level: Debug, Content: fmt.Sprintf("Shell %s is available in the runner image", out)})
+	}
+
+	return Result{Status: status, Messages: msg}
+}

--- a/pkg/preflight/task_supported_shells.go
+++ b/pkg/preflight/task_supported_shells.go
@@ -26,9 +26,8 @@ func (s *StepShellCheck) DependsOn() []string {
 
 func (s *StepShellCheck) Run(ctx *Context, _ Options) Result {
 	var (
-		msg []Message
-
 		status = Passed
+		msg    = make([]Message, 0)
 	)
 
 	// TODO: look better way other than hard-coding the list of not supported shells.
@@ -43,7 +42,7 @@ func (s *StepShellCheck) Run(ctx *Context, _ Options) Result {
 	// runner container
 	runner := config.Client().Container().From(config.RunnerImage())
 
-	for shell, _ := range ctx.Shells {
+	for shell := range ctx.Shells {
 		if _, ok := notSupportedShells[shell]; ok {
 			status = Failed
 			msg = append(msg, Message{Level: Error, Content: fmt.Sprintf("Shell %s is not supported", shell)})

--- a/pkg/preflight/task_supported_shells.go
+++ b/pkg/preflight/task_supported_shells.go
@@ -2,8 +2,9 @@ package preflight
 
 import (
 	"fmt"
-	"github.com/aweris/gale/internal/config"
 	"strings"
+
+	"github.com/aweris/gale/internal/config"
 )
 
 var _ Task = new(StepShellCheck)
@@ -20,7 +21,7 @@ func (s *StepShellCheck) Type() TaskType {
 }
 
 func (s *StepShellCheck) DependsOn() []string {
-	return []string{NameWorkflowLoader}
+	return []string{NameDockerImagesCheck, NameWorkflowLoader}
 }
 
 func (s *StepShellCheck) Run(ctx *Context, _ Options) Result {

--- a/pkg/preflight/task_workflows.go
+++ b/pkg/preflight/task_workflows.go
@@ -152,6 +152,7 @@ func (c *WorkflowLoader) Run(ctx *Context, opts Options) Result {
 
 			// empty shell means the default shell. skip it.
 			if step.Shell == "" {
+				ctx.Shells["bash"] = true // default shell is bash
 				continue
 			}
 


### PR DESCRIPTION
Extends preflight checks with:

- Validates availability of docker images
- Validates support of the step run shell values
- Validates support of used expression (*really basic, not catch everything)
- Validated support of the step action

We can use these to perform basic validation. This will help us determine whether to continue extending the experimental command or revert changes.

![validate](https://github.com/aweris/gale/assets/9319656/bbdbccce-3514-4a5c-879e-e7683d643bf1)

Execution of validate for `hofstadter-io/hof` repo `dagger/inception` workflow and job combination
