### PR TITLE
feat: add support for `jobs.<job_id>.outputs`

### DIFF
--- a/ci/workflows/job-outputs.yaml
+++ b/ci/workflows/job-outputs.yaml
@@ -1,0 +1,15 @@
+name: Job Outputs
+
+on: push
+
+jobs:
+  gen-outputs:
+    runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.step1.outputs.test }}
+      output2: ${{ steps.step2.outputs.test }}
+    steps:
+      - id: step1
+        run: echo "test=hello" >> "$GITHUB_OUTPUT"
+      - id: step2
+        run: echo "test=world" >> "$GITHUB_OUTPUT"

--- a/internal/core/env_file.go
+++ b/internal/core/env_file.go
@@ -16,10 +16,10 @@ import (
 // Name of the environment files used by github actions with the names used in the documentation. These names are list
 // of the possible environment files that can be used by github actions. They do not represent the actual file names.
 const (
-	EnvFileNameGithubEnv          = "GITHUB_ENV"
-	EnvFileNameGithubPath         = "GITHUB_PATH"
-	EnvFileNameGithubStepSummary  = "GITHUB_STEP_SUMMARY"
-	EnvFileNameGithubActionOutput = "GITHUB_ACTION_OUTPUT"
+	EnvFileNameGithubEnv         = "GITHUB_ENV"
+	EnvFileNameGithubPath        = "GITHUB_PATH"
+	EnvFileNameGithubStepSummary = "GITHUB_STEP_SUMMARY"
+	EnvFileNameGithubOutput      = "GITHUB_OUTPUT"
 )
 
 // EnvironmentFile represents a generated temporary file that can be used to perform certain actions. This struct is

--- a/internal/core/job.go
+++ b/internal/core/job.go
@@ -15,9 +15,10 @@ import (
 //
 // See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id
 type Job struct {
-	Name  string            `yaml:"name"`  // Name is the name of the job
-	Env   map[string]string `yaml:"env"`   // Env is the environment variables used in the workflow
-	Steps []Step            `yaml:"steps"` // Steps is the list of steps in the job
+	Name    string            `yaml:"name"`    // Name is the name of the job
+	Env     map[string]string `yaml:"env"`     // Env is the environment variables used in the workflow
+	Outputs map[string]string `yaml:"outputs"` // Outputs is the list of outputs of the job
+	Steps   []Step            `yaml:"steps"`   // Steps is the list of steps in the job
 
 	// TBD: add more fields when needed
 }

--- a/pkg/ghx/cmd_executor.go
+++ b/pkg/ghx/cmd_executor.go
@@ -196,7 +196,7 @@ func (c *CmdExecutor) loadEnvFiles() error {
 		return err
 	}
 
-	c.env[core.EnvFileNameGithubActionOutput] = outputs.Path
+	c.env[core.EnvFileNameGithubOutput] = outputs.Path
 	c.envFiles.Outputs = outputs
 
 	stepSummary, err := core.NewLocalEnvironmentFile(filepath.Join(dir, "step_summary"))

--- a/pkg/ghx/container_executor.go
+++ b/pkg/ghx/container_executor.go
@@ -207,7 +207,7 @@ func (c *ContainerExecutor) loadEnvFiles() error {
 		WithMountedDirectory(root, dir).
 		WithEnvVariable(core.EnvFileNameGithubEnv, env).
 		WithEnvVariable(core.EnvFileNameGithubPath, path).
-		WithEnvVariable(core.EnvFileNameGithubActionOutput, outputs).
+		WithEnvVariable(core.EnvFileNameGithubOutput, outputs).
 		WithEnvVariable(core.EnvFileNameGithubStepSummary, stepSummary)
 
 	// update the expression context with the environment files

--- a/pkg/ghx/runner.go
+++ b/pkg/ghx/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/aweris/gale/internal/core"
+	"github.com/aweris/gale/internal/expression"
 	"github.com/aweris/gale/internal/log"
 )
 
@@ -131,6 +132,16 @@ func setup(_ *Runner, setupFns ...TaskExecutorFn) TaskExecutorFn {
 // complete returns a task executor function that will be executed by the task executor for the complete step.
 func complete(r *Runner) TaskExecutorFn {
 	return func(ctx context.Context) (core.Conclusion, error) {
+
+		for k, v := range r.jr.Job.Outputs {
+			val, err := expression.NewString(v).Eval(r.context)
+			if err != nil {
+				return core.ConclusionFailure, err
+			}
+
+			log.Debugf("Evaluated output", "key", k, "value", val)
+		}
+
 		log.Infof("Complete", "job", r.jr.Job.Name, "conclusion", r.context.Job.Status)
 
 		return core.ConclusionSuccess, nil

--- a/pkg/ghx/runner.go
+++ b/pkg/ghx/runner.go
@@ -129,9 +129,14 @@ func setup(_ *Runner, setupFns ...TaskExecutorFn) TaskExecutorFn {
 	}
 }
 
+// MB is the megabyte size in bytes. It'll be used to check size of the job outputs. This just to increase the
+// readability of the code.
+const MB = 1024 * 1024
+
 // complete returns a task executor function that will be executed by the task executor for the complete step.
 func complete(r *Runner) TaskExecutorFn {
 	return func(ctx context.Context) (core.Conclusion, error) {
+		totalSize := 0
 
 		for k, v := range r.jr.Job.Outputs {
 			val, err := expression.NewString(v).Eval(r.context)
@@ -140,6 +145,24 @@ func complete(r *Runner) TaskExecutorFn {
 			}
 
 			log.Debugf("Evaluated output", "key", k, "value", val)
+
+			// According to Github Action docs, Outputs are Unicode strings, and can be a maximum of 1 MB in size.
+			// We'll check the size of the output and log a warning if it's bigger than 1MB.
+			//
+			// See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
+			if len(val) > 1*MB {
+				log.Warnf("Size of the output is bigger than 1MB", "key", k, "size", fmt.Sprintf("%dMB", len(val)/MB))
+			}
+
+			totalSize += len(val)
+		}
+
+		// According to Github Action docs, The total of all outputs in a workflow run can be a maximum of 50 MB.
+		// We'll check the size of the outputs and log a warning if it's bigger than 50MB.
+		//
+		// See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
+		if totalSize > 50*MB {
+			log.Warnf("Total size of the outputs is bigger than 50MB", "size", fmt.Sprintf("%dMB", totalSize/MB))
 		}
 
 		log.Infof("Complete", "job", r.jr.Job.Name, "conclusion", r.context.Job.Status)


### PR DESCRIPTION
Initial support for `job.<job_id>.outputs`

Related with #117 