### PR TITLE
refactor: add no log client to reduce logs in execution

### DIFF
--- a/cmd/gale/list/list.go
+++ b/cmd/gale/list/list.go
@@ -3,12 +3,11 @@ package list
 import (
 	"fmt"
 
-	"dagger.io/dagger"
-
 	"github.com/spf13/cobra"
 
 	"github.com/aweris/gale/internal/config"
 	"github.com/aweris/gale/internal/core"
+	"github.com/aweris/gale/internal/dagger/helpers"
 )
 
 // NewCommand  creates a new root command.
@@ -24,12 +23,19 @@ func NewCommand() *cobra.Command {
 		Short: "List all workflows and jobs under it",
 		Args:  cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			client, err := dagger.Connect(cmd.Context(), dagger.WithLogOutput(cmd.OutOrStdout()))
+			client, err := helpers.DefaultClient(cmd.Context())
 			if err != nil {
 				return err
 			}
 
 			config.SetClient(client)
+
+			clientNoLog, err := helpers.NoLogClient(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			config.SetClientNoLog(clientNoLog)
 
 			return nil
 		},

--- a/cmd/gale/run/run.go
+++ b/cmd/gale/run/run.go
@@ -1,12 +1,11 @@
 package run
 
 import (
-	"dagger.io/dagger"
-
 	"github.com/spf13/cobra"
 
 	"github.com/aweris/gale/internal/config"
 	"github.com/aweris/gale/internal/core"
+	"github.com/aweris/gale/internal/dagger/helpers"
 	"github.com/aweris/gale/pkg/gale"
 )
 
@@ -27,12 +26,19 @@ func NewCommand() *cobra.Command {
 		Args:         cobra.ExactArgs(2),
 		SilenceUsage: true, // don't print usage when error occurs
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			client, err := dagger.Connect(cmd.Context(), dagger.WithLogOutput(cmd.OutOrStdout()))
+			client, err := helpers.DefaultClient(cmd.Context())
 			if err != nil {
 				return err
 			}
 
 			config.SetClient(client)
+
+			clientNoLog, err := helpers.NoLogClient(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			config.SetClientNoLog(clientNoLog)
 
 			if runnerImage != "" {
 				config.SetRunnerImage(runnerImage)

--- a/cmd/gale/validate/validate.go
+++ b/cmd/gale/validate/validate.go
@@ -1,11 +1,10 @@
 package validate
 
 import (
-	"dagger.io/dagger"
-
 	"github.com/spf13/cobra"
 
 	"github.com/aweris/gale/internal/config"
+	"github.com/aweris/gale/internal/dagger/helpers"
 	"github.com/aweris/gale/pkg/preflight"
 )
 
@@ -23,12 +22,19 @@ func NewCommand() *cobra.Command {
 		Hidden:       true, // It's hidden because it's not ready yet.
 		SilenceUsage: true, // don't print usage when error occurs
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			client, err := dagger.Connect(cmd.Context())
+			client, err := helpers.DefaultClient(cmd.Context())
 			if err != nil {
 				return err
 			}
 
 			config.SetClient(client)
+
+			clientNoLog, err := helpers.NoLogClient(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			config.SetClientNoLog(clientNoLog)
 
 			if runnerImage != "" {
 				config.SetRunnerImage(runnerImage)

--- a/cmd/ghx/root.go
+++ b/cmd/ghx/root.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"dagger.io/dagger"
-
 	"github.com/spf13/cobra"
 
 	"github.com/aweris/gale/cmd/ghx/run"
@@ -13,6 +11,7 @@ import (
 	"github.com/aweris/gale/internal/cmd/version"
 	"github.com/aweris/gale/internal/config"
 	"github.com/aweris/gale/internal/core"
+	"github.com/aweris/gale/internal/dagger/helpers"
 	"github.com/aweris/gale/internal/fs"
 	"github.com/aweris/gale/internal/journal"
 	"github.com/aweris/gale/internal/log"
@@ -34,22 +33,19 @@ func NewCommand() *cobra.Command {
 
 			config.SetGhxHome(homeDir)
 
-			// initialize dagger client and set it to config
-			var opts []dagger.ClientOpt
-
-			journalW, journalR := journal.Pipe()
-
-			// Just print the same logger to stdout for now. We'll replace this with something interesting later.
-			go logJournalEntries(journalR)
-
-			opts = append(opts, dagger.WithLogOutput(journalW))
-
-			client, err := dagger.Connect(cmd.Context(), opts...)
+			client, err := helpers.NewClient(cmd.Context(), logJournalEntries)
 			if err != nil {
 				return err
 			}
 
 			config.SetClient(client)
+
+			clientNoLog, err := helpers.NoLogClient(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			config.SetClientNoLog(clientNoLog)
 
 			return nil
 		},
@@ -79,43 +75,36 @@ func Execute() {
 	}
 }
 
-func logJournalEntries(reader journal.Reader) {
-	for {
-		entry, ok := reader.ReadEntry()
-		if !ok {
-			break
-		}
+func logJournalEntries(entry *journal.Entry) {
+	// Skip internal entries if we're not in debug mode
+	if entry.Type == journal.EntryTypeInternal && !config.Debug() {
+		return
+	}
 
-		// Skip internal entries if we're not in debug mode
-		if entry.Type == journal.EntryTypeInternal && !config.Debug() {
-			continue
-		}
+	isCommand, command := core.ParseCommand(entry.Message)
+	if !isCommand {
+		log.Info(entry.Message)
+		return
+	}
 
-		isCommand, command := core.ParseCommand(entry.Message)
-		if !isCommand {
-			log.Info(entry.Message)
-			continue
-		}
+	// TODO: We should extract these to common place, currently we're duplicating the code when we need to parse the commands
 
-		// TODO: We should extract these to common place, currently we're duplicating the code when we need to parse the commands
-
-		// process only logging based commands and ignore the rest
-		switch command.Name {
-		case "group":
-			log.Info(command.Value)
-			log.StartGroup()
-		case "endgroup":
-			log.EndGroup()
-		case "debug":
-			log.Debug(command.Value)
-		case "error":
-			log.Errorf(command.Value, "file", command.Parameters["file"], "line", command.Parameters["line"], "col", command.Parameters["col"], "endLine", command.Parameters["endLine"], "endCol", command.Parameters["endCol"], "title", command.Parameters["title"])
-		case "warning":
-			log.Warnf(command.Value, "file", command.Parameters["file"], "line", command.Parameters["line"], "col", command.Parameters["col"], "endLine", command.Parameters["endLine"], "endCol", command.Parameters["endCol"], "title", command.Parameters["title"])
-		case "notice":
-			log.Noticef(command.Value, "file", command.Parameters["file"], "line", command.Parameters["line"], "col", command.Parameters["col"], "endLine", command.Parameters["endLine"], "endCol", command.Parameters["endCol"], "title", command.Parameters["title"])
-		default:
-			// do nothing
-		}
+	// process only logging based commands and ignore the rest
+	switch command.Name {
+	case "group":
+		log.Info(command.Value)
+		log.StartGroup()
+	case "endgroup":
+		log.EndGroup()
+	case "debug":
+		log.Debug(command.Value)
+	case "error":
+		log.Errorf(command.Value, "file", command.Parameters["file"], "line", command.Parameters["line"], "col", command.Parameters["col"], "endLine", command.Parameters["endLine"], "endCol", command.Parameters["endCol"], "title", command.Parameters["title"])
+	case "warning":
+		log.Warnf(command.Value, "file", command.Parameters["file"], "line", command.Parameters["line"], "col", command.Parameters["col"], "endLine", command.Parameters["endLine"], "endCol", command.Parameters["endCol"], "title", command.Parameters["title"])
+	case "notice":
+		log.Noticef(command.Value, "file", command.Parameters["file"], "line", command.Parameters["line"], "col", command.Parameters["col"], "endLine", command.Parameters["endLine"], "endCol", command.Parameters["endCol"], "title", command.Parameters["title"])
+	default:
+		// do nothing
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,8 +20,12 @@ func init() {
 	cfg.runnerImage = "ghcr.io/aweris/gale/runner/ubuntu:22.04"
 }
 
+// TODO: need some change here to make it more maintainable. This became a hacky mess and it's hard to maintain or
+//  track where it's used.
+
 type config struct {
 	client      *dagger.Client // client is the dagger client for the config.
+	clientNoLog *dagger.Client // clientNoLog is the dagger client without logging.
 	runnerImage string         // runnerImage is the image used for running the actions.
 	ghxHome     string         // ghxHome directory where all the data is stored.
 	debug       bool           // debug is the flag to enable debug mode.
@@ -35,6 +39,16 @@ func SetClient(client *dagger.Client) {
 // Client returns the dagger client for the config.
 func Client() *dagger.Client {
 	return cfg.client
+}
+
+// SetClientNoLog sets the dagger client without logging for the config.
+func SetClientNoLog(client *dagger.Client) {
+	cfg.clientNoLog = client
+}
+
+// ClientNoLog returns the dagger client without logging for the config.
+func ClientNoLog() *dagger.Client {
+	return cfg.clientNoLog
 }
 
 // SetRunnerImage sets the runner image for the config.

--- a/internal/core/repository_gitref.go
+++ b/internal/core/repository_gitref.go
@@ -56,7 +56,7 @@ func GetRepositoryRefFromDir(ctx context.Context, dir *dagger.Directory) (*Repos
 		sha     string
 	)
 
-	out, err := config.Client().
+	out, err := config.ClientNoLog().
 		Container().
 		From("alpine/git").
 		WithMountedDirectory("/src", dir).WithWorkdir("/src").
@@ -88,7 +88,7 @@ func GetRepositoryRefFromDir(ctx context.Context, dir *dagger.Directory) (*Repos
 }
 
 func getRepoSHA(ctx context.Context, dir *dagger.Directory) (string, error) {
-	out, err := config.Client().
+	out, err := config.ClientNoLog().
 		Container().
 		From("alpine/git").
 		WithMountedDirectory("/src", dir).WithWorkdir("/src").

--- a/internal/dagger/helpers/client.go
+++ b/internal/dagger/helpers/client.go
@@ -1,0 +1,64 @@
+package helpers
+
+import (
+	"context"
+	"os"
+
+	"dagger.io/dagger"
+
+	"github.com/aweris/gale/internal/journal"
+)
+
+// LogFunc is the function that will be called when a new journal entry is received for default dagger client.
+type LogFunc func(entry *journal.Entry)
+
+// NoopLogFunc is a log function that does nothing.
+func NoopLogFunc(_ *journal.Entry) {}
+
+// DefaultClient creates a new dagger client that logs to stdout.
+func DefaultClient(ctx context.Context) (*dagger.Client, error) {
+	return NewClient(ctx, nil)
+}
+
+// TODO: no log client is ok for now but what we really need is a client that logs to a file so we can use it for
+//  debugging. However, we can add this on later iterations.
+
+// NoLogClient creates a new dagger client that does not log anything.
+func NoLogClient(ctx context.Context) (*dagger.Client, error) {
+	return NewClient(ctx, NoopLogFunc)
+}
+
+// NewClient creates a new dagger client with given log function.
+func NewClient(ctx context.Context, logFn LogFunc) (*dagger.Client, error) {
+	// initialize dagger client and set it to config
+	var opts []dagger.ClientOpt
+
+	if logFn != nil {
+		journalW, journalR := journal.Pipe()
+
+		// Just print the same logger to stdout for now. We'll replace this with something interesting later.
+		go logJournal(journalR, logFn)
+
+		opts = append(opts, dagger.WithLogOutput(journalW))
+	} else {
+		opts = append(opts, dagger.WithLogOutput(os.Stdout))
+	}
+
+	client, err := dagger.Connect(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func logJournal(reader journal.Reader, logFn LogFunc) {
+	for {
+		entry, ok := reader.ReadEntry()
+		if !ok {
+			break
+		}
+
+		logFn(entry)
+	}
+}


### PR DESCRIPTION
Introduces configurable logging for dagger client and adds No Log client to hide some unnecessary logs from the console. 

This is an initial improvement. We'll improve this in follow-up commits

Depends on #120 