### PR TITLE
feat: make job name filter is a option flag

### DIFF
--- a/ci/workflows/job-outputs.yaml
+++ b/ci/workflows/job-outputs.yaml
@@ -1,4 +1,4 @@
-name: Job Outputs
+name: outputs
 
 on: push
 
@@ -13,3 +13,10 @@ jobs:
         run: echo "test=hello" >> "$GITHUB_OUTPUT"
       - id: step2
         run: echo "test=world" >> "$GITHUB_OUTPUT"
+
+  use-outputs:
+    needs: gen-outputs
+    runs-on: ubuntu-latest
+    steps:
+        - run: echo "output1=${{ needs.gen-outputs.outputs.output1 }}"
+        - run: echo "output2=${{ needs.gen-outputs.outputs.output2 }}"

--- a/ci/workflows/step.yaml
+++ b/ci/workflows/step.yaml
@@ -1,0 +1,58 @@
+name: step
+
+on: push
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hello World
+        uses: actions/hello-world-javascript-action@v1
+
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Default Shell
+        run: echo "Hello World"
+
+      - name: Bash Shell
+        shell: bash
+        run: echo "Hello World"
+
+      - name: Python Shell
+        shell: python
+        run: print("Hello World")
+
+      - name: SH Shell
+        shell: sh
+        run: echo "Hello World"
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git log
+        uses: docker://alpine/git:latest
+        with:
+          args: log --pretty=oneline
+
+      - name: Print go.mod
+        uses: docker://alpine:latest
+        with:
+          entrypoint: /bin/cat
+          args: go.mod
+
+      - name: Use env and expression
+        uses: docker://alpine:latest
+        with:
+          entrypoint: /bin/echo
+          args: ${{ github.repository }}
+
+      - name: SVU version bump custom docker action
+        uses: jsok/svu-version-bump-action@v2
+        id: bump
+        with:
+          bump: 'patch'
+
+      - name: Print the version
+        run: echo "The version is ${{ steps.bump.outputs.version }}"
+

--- a/cmd/gale/run/run.go
+++ b/cmd/gale/run/run.go
@@ -18,14 +18,15 @@ func NewCommand() *cobra.Command {
 		branch       string            // branch is the branch to load workflows from.
 		tag          string            // tag is the tag to load workflows from.
 		workflowsDir string            // workflowsDir is the directory to load workflows from.
+		job          string            // job is the job name to run.
 		secrets      map[string]string // secrets is the map of secrets to be used in the workflow.
 		rc           *gctx.Context
 	)
 
 	cmd := &cobra.Command{
-		Use:          "run <workflow> <job> [flags]",
+		Use:          "run <workflow> [flags]",
 		Short:        "Run Github Actions by providing workflow and job name",
-		Args:         cobra.ExactArgs(2),
+		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true, // don't print usage when error occurs
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			client, err := helpers.DefaultClient(cmd.Context())
@@ -74,7 +75,7 @@ func NewCommand() *cobra.Command {
 			_, err := config.Client().Container().
 				From(config.RunnerImage()).
 				With(gi.ExecutionEnv(cmd.Context())).
-				With(gi.Run(args[0], args[1])).
+				With(gi.Run(args[0], job)).
 				Sync(cmd.Context())
 
 			if err != nil {
@@ -91,6 +92,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&branch, "branch", "", "branch to load workflows from. Only one of branch or tag can be used. Precedence is as follows: tag, branch.")
 	cmd.Flags().StringVar(&tag, "tag", "", "tag to load workflows from. Only one of branch or tag can be used. Precedence is as follows: tag, branch.")
 	cmd.Flags().StringVar(&workflowsDir, "workflows-dir", "", "directory to load workflows from. If empty, workflows will be loaded from the default directory.")
+	cmd.Flags().StringVarP(&job, "job", "j", "", "job name to run")
 	cmd.Flags().StringToStringVar(&secrets, "secret", nil, "secrets to be used in the workflow. Format: --secret name=value")
 
 	return cmd

--- a/cmd/ghx/run/run.go
+++ b/cmd/ghx/run/run.go
@@ -10,10 +10,12 @@ import (
 
 // NewCommand  creates a new root command.
 func NewCommand() *cobra.Command {
+	var job string
+
 	command := &cobra.Command{
-		Use:   "run <workflow> <job> [flags]",
+		Use:   "run <workflow> [flags]",
 		Short: "Runs a job given run id",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Load context
 			ctx, err := gctx.Load(cmd.Context(), config.Debug())
@@ -33,7 +35,7 @@ func NewCommand() *cobra.Command {
 			}
 
 			// Create task runner for the workflow
-			runner, err := ghx.Plan(wf, args[1])
+			runner, err := ghx.Plan(wf, job)
 			if err != nil {
 				return err
 			}
@@ -47,6 +49,8 @@ func NewCommand() *cobra.Command {
 			return nil
 		},
 	}
+
+	command.Flags().StringVarP(&job, "job", "j", "", "job name to run")
 
 	return command
 }

--- a/internal/core/job.go
+++ b/internal/core/job.go
@@ -1,16 +1,48 @@
 package core
 
+import "gopkg.in/yaml.v3"
+
 // Job represents a single job in a GitHub Actions workflow
 //
 // See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id
 type Job struct {
 	ID      string            `yaml:"id"`      // ID is the ID of the job
+	If      string            `yaml:"if"`      // If is the conditional expression to run the job.
 	Name    string            `yaml:"name"`    // Name is the name of the job
+	Needs   Needs             `yaml:"needs"`   // Needs is the list of jobs that must be completed before this job will run
 	Env     map[string]string `yaml:"env"`     // Env is the environment variables used in the workflow
 	Outputs map[string]string `yaml:"outputs"` // Outputs is the list of outputs of the job
 	Steps   []Step            `yaml:"steps"`   // Steps is the list of steps in the job
 
 	// TBD: add more fields when needed
+}
+
+// Needs is the list of jobs that must be completed before this job will run
+type Needs []string
+
+// UnmarshalYAML implements yaml.Unmarshaler interface for Needs. It supports both scalar and sequence nodes.
+//
+// Example:
+//
+//	needs: build # scalar node
+//	needs: # sequence node
+//	  - build
+//	  - test
+func (n *Needs) UnmarshalYAML(value *yaml.Node) error {
+	var needs []string
+
+	switch value.Kind {
+	case yaml.ScalarNode:
+		needs = append(needs, value.Value)
+	case yaml.SequenceNode:
+		for _, node := range value.Content {
+			needs = append(needs, node.Value)
+		}
+	}
+
+	*n = needs
+
+	return nil
 }
 
 // JobRun represents a single job run in a GitHub Actions workflow run

--- a/internal/core/workflow.go
+++ b/internal/core/workflow.go
@@ -18,5 +18,6 @@ type WorkflowRun struct {
 	RunAttempt    string            `json:"run_attempt"`    // RunAttempt is the attempt number of the run
 	RetentionDays string            `json:"retention_days"` // RetentionDays is the number of days to keep the run logs
 	Workflow      Workflow          `json:"workflow"`       // Workflow is the workflow to run
+	Conclusion    Conclusion        `json:"conclusion"`     // Conclusion is the result of a completed workflow run after continue-on-error is applied
 	Jobs          map[string]JobRun `json:"jobs"`           // Jobs is map of the job run id to its result
 }

--- a/internal/gctx/gctx.go
+++ b/internal/gctx/gctx.go
@@ -30,6 +30,7 @@ type Context struct {
 	Inputs  InputsContext
 	Job     JobContext
 	Steps   StepsContext
+	Needs   NeedsContext
 }
 
 func Load(ctx context.Context, debug bool) (*Context, error) {
@@ -130,7 +131,7 @@ func (c *Context) GetVariable(name string) (interface{}, error) {
 	case "matrix":
 		return map[string]string{}, nil
 	case "needs":
-		return map[string]string{}, nil
+		return c.Needs, nil
 	case "inputs":
 		return c.Inputs, nil
 	case "infinity":

--- a/internal/gctx/job.go
+++ b/internal/gctx/job.go
@@ -11,13 +11,13 @@ type JobContext struct {
 	// TODO: add other fields when needed.
 }
 
-func (c *Context) LoadJob() error {
+func (c *Context) LoadJob(status core.Conclusion) error {
 	c.Job = JobContext{}
 
 	// initial job status is success for workflows. Otherwise, default if condition check will skip the job.
 	// we're setting in only for container workflows because we don't need this value outside the container.
 	if c.isContainer {
-		c.Job.Status = core.ConclusionSuccess
+		c.Job.Status = status
 	}
 
 	return nil

--- a/internal/gctx/needs.go
+++ b/internal/gctx/needs.go
@@ -1,0 +1,21 @@
+package gctx
+
+import "github.com/aweris/gale/internal/core"
+
+// NeedContext is a context that contains information about dependent job.
+type NeedContext struct {
+	Result  core.Conclusion   `json:"result"`  // Result is conclusion of the job. It can be success, failure, skipped or cancelled.
+	Outputs map[string]string `json:"outputs"` // Outputs of the job
+}
+
+type NeedsContext map[string]NeedContext
+
+func (c *Context) LoadNeeds(runs ...core.JobRun) error {
+	c.Needs = make(NeedsContext)
+
+	for _, jr := range runs {
+		c.Needs[jr.Job.ID] = NeedContext{Result: jr.Conclusion, Outputs: jr.Outputs}
+	}
+
+	return nil
+}

--- a/pkg/gale/ghx.go
+++ b/pkg/gale/ghx.go
@@ -50,6 +50,10 @@ func (g *Ghx) WithContainerFunc() dagger.WithContainerFunc {
 
 func (g *Ghx) Run(workflow, job string) dagger.WithContainerFunc {
 	return func(container *dagger.Container) *dagger.Container {
-		return container.WithExec([]string{"/usr/local/bin/ghx", "run", workflow, job})
+		if job != "" {
+			return container.WithExec([]string{"/usr/local/bin/ghx", "run", workflow, "--job", job})
+		}
+
+		return container.WithExec([]string{"/usr/local/bin/ghx", "run", workflow})
 	}
 }

--- a/pkg/ghx/helpers.go
+++ b/pkg/ghx/helpers.go
@@ -25,9 +25,9 @@ func getStepName(prefix string, s core.Step) string {
 	}
 }
 
-// evalStepCondition evaluates the given condition and returns the result. If the condition is empty, then it uses
+// evalCondition evaluates the given condition and returns the result. If the condition is empty, then it uses
 // success() as default.
-func evalStepCondition(condition string, ac *gctx.Context) (bool, core.Conclusion, error) {
+func evalCondition(condition string, ac *gctx.Context) (bool, core.Conclusion, error) {
 	// if condition is empty, then use success() as default
 	if condition == "" {
 		condition = "success()"

--- a/pkg/ghx/step.go
+++ b/pkg/ghx/step.go
@@ -127,7 +127,7 @@ func (s *StepAction) preCondition() TaskConditionalFn {
 			return false, "", nil
 		}
 
-		return evalStepCondition(condition, ctx)
+		return evalCondition(condition, ctx)
 	}
 }
 
@@ -151,7 +151,7 @@ func (s *StepAction) pre() TaskRunFn {
 
 func (s *StepAction) condition() TaskConditionalFn {
 	return func(ctx *gctx.Context) (bool, core.Conclusion, error) {
-		return evalStepCondition(s.Step.If, ctx)
+		return evalCondition(s.Step.If, ctx)
 	}
 }
 
@@ -180,7 +180,7 @@ func (s *StepAction) postCondition() TaskConditionalFn {
 			return false, "", nil
 		}
 
-		return evalStepCondition(condition, ctx)
+		return evalCondition(condition, ctx)
 	}
 }
 
@@ -215,7 +215,7 @@ type StepRun struct {
 
 func (s *StepRun) condition() TaskConditionalFn {
 	return func(ctx *gctx.Context) (bool, core.Conclusion, error) {
-		return evalStepCondition(s.Step.If, ctx)
+		return evalCondition(s.Step.If, ctx)
 	}
 }
 
@@ -349,7 +349,7 @@ func (s *StepDocker) setup() TaskRunFn {
 
 func (s *StepDocker) condition() TaskConditionalFn {
 	return func(ctx *gctx.Context) (bool, core.Conclusion, error) {
-		return evalStepCondition(s.Step.If, ctx)
+		return evalCondition(s.Step.If, ctx)
 	}
 }
 

--- a/pkg/ghx/workflow.go
+++ b/pkg/ghx/workflow.go
@@ -7,23 +7,66 @@ import (
 	"github.com/aweris/gale/internal/core"
 	"github.com/aweris/gale/internal/gctx"
 	"github.com/aweris/gale/internal/idgen"
+	"github.com/aweris/gale/internal/log"
 )
 
 var ErrWorkflowNotFound = errors.New("workflow not found")
 
 // Plan plans the workflow and returns the workflow runner.
 func Plan(workflow core.Workflow, job string) (*TaskRunner, error) {
-	var order []string
+	var (
+		order   []string                // order keeps track of job execution order
+		visited map[string]bool         // visited keeps track of visited jobs
+		visitFn func(name string) error // visitFn is the function that visits the job and its dependencies recursively to create the execution order
+	)
 
+	visited = make(map[string]bool)
+
+	visitFn = func(name string) error {
+		if _, exist := workflow.Jobs[name]; !exist {
+			return fmt.Errorf("job %s not found", name)
+		}
+
+		if visited[name] {
+			return nil
+		}
+
+		visited[name] = true
+		for _, need := range workflow.Jobs[name].Needs {
+			if err := visitFn(need); err != nil {
+				return err
+			}
+		}
+
+		order = append(order, name)
+
+		return nil
+	}
+
+	// if job is specified, visit only that job and its dependencies otherwise visit all jobs
 	if job != "" {
-		order = []string{job}
+		if err := visitFn(job); err != nil {
+			return nil, err
+		}
 	} else {
-		// TODO: order jobs based on dependencies. For now, just run all jobs in the workflow.
 		for name := range workflow.Jobs {
-			order = append(order, name)
+			if err := visitFn(name); err != nil {
+				return nil, err
+			}
 		}
 	}
 
+	// if no jobs found for execution, return error
+	if len(order) == 0 {
+		return nil, errors.New("no jobs found")
+	}
+
+	// log the execution order if there are more than one job
+	if len(order) > 1 {
+		log.Infof("Job execution order", "jobs", order)
+	}
+
+	// runFn is the function that runs the workflow
 	runFn := func(ctx *gctx.Context) (core.Conclusion, error) {
 		for _, job := range order {
 			jm, ok := workflow.Jobs[job]
@@ -46,8 +89,12 @@ func Plan(workflow core.Workflow, job string) (*TaskRunner, error) {
 	}
 
 	// workflow task options
-	opt := TaskOpts{PreRunFn: newTaskPreRunFnForWorkflow(workflow)}
+	opt := TaskOpts{
+		PreRunFn:  newTaskPreRunFnForWorkflow(workflow),
+		PostRunFn: newTaskPostRunFnForWorkflow(),
+	}
 
+	// create the workflow task runner from the runFn and options
 	runner := NewTaskRunner(fmt.Sprintf("Workflow: %s", workflow.Name), runFn, opt)
 
 	return &runner, nil
@@ -70,5 +117,12 @@ func newTaskPreRunFnForWorkflow(wf core.Workflow) TaskPreRunFn {
 				Jobs:          make(map[string]core.JobRun),
 			},
 		)
+	}
+}
+
+func newTaskPostRunFnForWorkflow() TaskPostRunFn {
+	return func(ctx *gctx.Context) error {
+		log.Infof("Complete", "workflow", ctx.Execution.WorkflowRun.Workflow.Name, "conclusion", ctx.Execution.WorkflowRun.Conclusion)
+		return nil
 	}
 }


### PR DESCRIPTION
With this update, the `gale` tool extends its capabilities to run entire workflows locally, instead of being limited to individual jobs. 
