### PR TITLE
refactor: simplify command dx

### DIFF
--- a/daggerverse/gale/opts.go
+++ b/daggerverse/gale/opts.go
@@ -1,0 +1,99 @@
+package main
+
+// RepoOpts represents the options for getting repository information.
+//
+// This is copy of RepoOpts from daggerverse/gale/repo.go to be able to expose options with gale module and pass them to
+// the repo module just type casting.
+type RepoOpts struct {
+	Source *Directory `doc:"The directory containing the repository source. If source is provided, rest of the options are ignored."`
+	Repo   string     `doc:"The name of the repository. Format: owner/name."`
+	Branch string     `doc:"Branch name to checkout. Only one of branch or tag can be used. Precedence is as follows: tag, branch."`
+	Tag    string     `doc:"Tag name to checkout. Only one of branch or tag can be used. Precedence is as follows: tag, branch."`
+}
+
+// WorkflowsDirOpts represents the options for getting workflow information.
+type WorkflowsDirOpts struct {
+	WorkflowsDir string `doc:"The relative path to the workflow directory." default:".github/workflows"`
+}
+
+// WorkflowsRunOpts represents the options for running a workflow.
+type WorkflowsRunOpts struct {
+	Workflow    string  `doc:"The workflow to run." required:"true"`
+	Job         string  `doc:"The job name to run. If empty, all jobs will be run."`
+	Event       string  `doc:"Name of the event that triggered the workflow. e.g. push" default:"push"`
+	EventFile   *File   `doc:"The file with the complete webhook event payload."`
+	RunnerImage string  `doc:"The image to use for the runner." default:"ghcr.io/catthehacker/ubuntu:act-latest"`
+	RunnerDebug bool    `doc:"Enable debug mode." default:"false"`
+	Token       *Secret `doc:"The GitHub token to use for authentication."`
+}
+
+// WorkflowRunDirectoryOpts represents the options for exporting a workflow run.
+type WorkflowRunDirectoryOpts struct {
+	IncludeRepo      bool `doc:"Include the repository source in the exported directory." default:"false"`
+	IncludeSecrets   bool `doc:"Include the secrets in the exported directory." default:"false"`
+	IncludeEvent     bool `doc:"Include the event file in the exported directory." default:"false"`
+	IncludeArtifacts bool `doc:"Include the artifacts in the exported directory." default:"false"`
+}
+
+// FIXME: add jobs to WorkflowRunReport when dagger supports map type
+
+// WorkflowRunReport represents the result of a workflow run.
+type WorkflowRunReport struct {
+	Ran           bool   `json:"ran"`            // Ran indicates if the execution ran
+	Duration      string `json:"duration"`       // Duration of the execution
+	Name          string `json:"name"`           // Name is the name of the workflow
+	Path          string `json:"path"`           // Path is the path of the workflow
+	RunID         string `json:"run_id"`         // RunID is the ID of the run
+	RunNumber     string `json:"run_number"`     // RunNumber is the number of the run
+	RunAttempt    string `json:"run_attempt"`    // RunAttempt is the attempt number of the run
+	RetentionDays string `json:"retention_days"` // RetentionDays is the number of days to keep the run logs
+	Conclusion    string `json:"conclusion"`     // Conclusion is the result of a completed workflow run after continue-on-error is applied
+}
+
+// Configuration objects
+
+// When dagger converts objects to commands. All public methods and fields converted to sub commands of that object.
+// To keep command DX simple when we need to pass options as a part of the state we're using config objects to hold the
+// options. This way we can keep the command DX simple and only one extra command is added to the command tree.
+
+// These config objects basically holds the options for the commands but to keep code code gen friendly we're duplicating
+// the options as fields of the config objects.
+
+// WorkflowRunConfig holds the configuration of a workflow run.
+type WorkflowRunConfig struct {
+	// Directory containing the repository source.
+	Source *Directory
+
+	// Name of the repository. Format: owner/name.
+	Repo string
+
+	// Branch name to check out. Only one of branch or tag can be used. Precedence: tag, branch.
+	Branch string
+
+	// Tag name to check out. Only one of branch or tag can be used. Precedence: tag, branch.
+	Tag string
+
+	// Path to the workflow directory.
+	WorkflowsDir string
+
+	// Workflow to run.
+	Workflow string
+
+	// Job name to run. If empty, all jobs will be run.
+	Job string
+
+	// Name of the event that triggered the workflow. e.g. push
+	Event string
+
+	// File with the complete webhook event payload.
+	EventFile *File
+
+	// Image to use for the runner.
+	RunnerImage string
+
+	// Enables debug mode.
+	RunnerDebug bool
+
+	// GitHub token to use for authentication.
+	Token *Secret
+}


### PR DESCRIPTION
Dagger command structure and options generated based on exposed fields and commands. This PR moves config object around to simplify `dagger call dx`

- **dagger call workflows run --help**

```shell
dagger call workflows run --help
✔ build "dagger call" [1.25s]
├ [0.80s] loading module
├ [0.45s] loading objects
✔ running "dagger call workflows run" [0.00s]
┃ Usage:
┃   dagger call workflows run [flags]
┃   dagger call workflows run [command]
┃
┃ Aliases:
┃   run, Run
┃
┃ Available Commands:
┃   config      Configuration for the workflow run.
┃
┃   directory   Directory returns the directory of the workflow run information.
┃   result      Result returns executes the workflow run and returns the result.
┃
┃ Flags:
┃       --branch string          Branch name to checkout. Only one of branch or tag can be used. Precedence is as follows: tag, branch.
┃       --event string           Name of the event that triggered the workflow. e.g. push (default "push")
┃       --event-file File        The file with the complete webhook event payload.
┃   -h, --help                   help for run
┃       --job string             The job name to run. If empty, all jobs will be run.
┃       --repo string            The name of the repository. Format: owner/name.
┃       --runner-debug           Enable debug mode.
┃       --runner-image string    The image to use for the runner. (default "ghcr.io/catthehacker/ubuntu:act-latest")
┃       --source Directory       The directory containing the repository source. If source is provided, rest of the options are ignored.
┃       --tag string             Tag name to checkout. Only one of branch or tag can be used. Precedence is as follows: tag, branch.
┃       --token Secret           The GitHub token to use for authentication.
┃       --workflow string        The workflow to run.
┃       --workflows-dir string   The relative path to the workflow directory. (default ".github/workflows")
┃
┃ Global Flags:
┃       --cpuprofile string   collect CPU profile to path, and trace at path.trace
┃       --debug               Show more information for debugging
┃       --focus               Only show output for focused commands. (default true)
┃   -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/d
┃ ") or a git repo (e.g. "git://github.com/dagger/dagger?ref=branch?subpath=path/to/some/dir").
┃       --pprof string        serve HTTP pprof at this address
┃       --progress string     progress output format (auto, plain, tty) (default "auto")
┃   -s, --silent              disable terminal UI and progress output
┃       --workdir string      The host workdir loaded into dagger (default ".")
┃
┃ Use "dagger call workflows run [command] --help" for more information about a command.
• Engine: 61b34bf9d33e (version v0.9.0)
⧗ 2.34s ✔ 31 ∅ 12
```

- **dagger call workflows run config --help**

```shell
dagger call workflows run config --help
✔ build "dagger call" [1.27s]
├ [0.88s] loading module
├ [0.40s] loading objects
✔ running "dagger call workflows run config" [0.00s]
┃ Configuration for the workflow run.
┃
┃ Usage:
┃   dagger call workflows run config [flags]
┃   dagger call workflows run config [command]
┃
┃ Aliases:
┃   config, Config
┃
┃ Available Commands:
┃   branch        Branch name to check out. Only one of branch or tag can be used. Precedence: tag, branch.
┃
┃   event         Name of the event that triggered the workflow. e.g. push
┃
┃   event-file    File with the complete webhook event payload.
┃
┃   job           Job name to run. If empty, all jobs will be run.
┃
┃   repo          Name of the repository. Format: owner/name.
┃
┃   runner-debug  Enables debug mode.
┃
┃   runner-image  Image to use for the runner.
┃
┃   source        Directory containing the repository source.
┃
┃   tag           Tag name to check out. Only one of branch or tag can be used. Precedence: tag, branch.
┃
┃   token         GitHub token to use for authentication.
┃
┃   workflow      Workflow to run.
┃
┃   workflows-dir Path to the workflow directory.
┃
┃
┃ Flags:
┃   -h, --help   help for config
┃
┃ Global Flags:
┃       --cpuprofile string   collect CPU profile to path, and trace at path.trace
┃       --debug               Show more information for debugging
┃       --focus               Only show output for focused commands. (default true)
┃   -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/d
┃ ") or a git repo (e.g. "git://github.com/dagger/dagger?ref=branch?subpath=path/to/some/dir").
┃       --pprof string        serve HTTP pprof at this address
┃       --progress string     progress output format (auto, plain, tty) (default "auto")
┃   -s, --silent              disable terminal UI and progress output
┃       --workdir string      The host workdir loaded into dagger (default ".")
┃
┃ Use "dagger call workflows run config [command] --help" for more information about a command.
• Engine: 61b34bf9d33e (version v0.9.0)
⧗ 2.48s ✔ 31 ∅ 12
```

config command has no practical usage at the moment. This is just to move all these from the `run` command structure