### PR TITLE
fix: remove unnecessary --image flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,10 @@ Available Commands:
 
 Flags:
       --branch string          Branch name to check out. Only one of branch or tag can be used. Precedence is as follows: tag, branch.
-      --container Container    Container to use for the runner. If --image and --container provided together, --image takes precedence.
+      --container Container    Container to use for the runner (default: ghcr.io/catthehacker/ubuntu:act-latest).
       --event string           Name of the event that triggered the workflow. e.g. push
       --event-file File        File with the complete webhook event payload.
   -h, --help                   help for run
-      --image string           Image to use for the runner. If --image and --container provided together, --image takes precedence.
       --job string             Name of the job to run. If empty, all jobs will be run.
       --repo string            The name of the repository. Format: owner/name.
       --runner-debug           Enables debug mode.

--- a/daggerverse/actions/runtime/action_run.go
+++ b/daggerverse/actions/runtime/action_run.go
@@ -39,10 +39,7 @@ type ActionRunConfig struct {
 	// File with the complete webhook event payload.
 	EventFile *File
 
-	// Image to use for the runner. If --image and --container provided together, --image takes precedence.
-	Image string
-
-	// Container to use for the runner. If --image and --container provided together, --image takes precedence.
+	// Container to use for the runner.
 	Container *Container
 
 	// Enables debug mode.
@@ -76,7 +73,6 @@ func (ar *ActionRun) Sync() (*Container, error) {
 		WorkflowFile: wf,
 		Event:        ar.Config.Event,
 		EventFile:    ar.Config.EventFile,
-		Image:        ar.Config.Image,
 		Container:    ar.Config.Container,
 		RunnerDebug:  ar.Config.RunnerDebug,
 		Token:        ar.Config.Token,

--- a/daggerverse/actions/runtime/actions_runtime.go
+++ b/daggerverse/actions/runtime/actions_runtime.go
@@ -18,9 +18,7 @@ func (m *ActionsRuntime) Run(
 	event Optional[string],
 	// File with the complete webhook event payload.
 	eventFile Optional[*File],
-	// Image to use for the runner. If --image and --container provided together, --image takes precedence.
-	image Optional[string],
-	// Container to use for the runner. If --image and --container provided together, --image takes precedence.
+	// Container to use for the runner(default: ghcr.io/catthehacker/ubuntu:act-latest).
 	container Optional[*Container],
 	// Enables debug mode.
 	runnerDebug Optional[bool],
@@ -38,7 +36,6 @@ func (m *ActionsRuntime) Run(
 			With:        []string{},
 			Event:       event.GetOr("push"),
 			EventFile:   eventFile.GetOr(nil),
-			Image:       image.GetOr(""), // default value handled by gale module. Handling it here would override the container if it is provided.
 			Container:   container.GetOr(nil),
 			RunnerDebug: runnerDebug.GetOr(false),
 			Token:       token.GetOr(nil),

--- a/daggerverse/gale/gale.go
+++ b/daggerverse/gale/gale.go
@@ -97,9 +97,7 @@ func (g *Gale) Run(
 	event Optional[string],
 	// File with the complete webhook event payload.
 	eventFile Optional[*File],
-	// Image to use for the runner. If --image and --container provided together, --image takes precedence.
-	image Optional[string],
-	// Container to use for the runner. If --image and --container provided together, --image takes precedence.
+	// Container to use for the runner(default: ghcr.io/catthehacker/ubuntu:act-latest).
 	container Optional[*Container],
 	// Enables debug mode.
 	runnerDebug Optional[bool],
@@ -148,7 +146,7 @@ func (g *Gale) Run(
 	}
 
 	return &WorkflowRun{
-		Runner: g.Runner().Container(ctx, image, container, source, repo, tag, branch),
+		Runner: g.Runner().Container(ctx, container, source, repo, tag, branch),
 		Config: WorkflowRunConfig{
 			WorkflowFile: wf,
 			Workflow:     wp,

--- a/daggerverse/gale/runner.go
+++ b/daggerverse/gale/runner.go
@@ -32,8 +32,6 @@ func (r *Runner) getRunnerContainer(ctx context.Context, container *Container) *
 func (r *Runner) Container(
 	// context to use for the operation
 	ctx context.Context,
-	// Image to use for the runner. If --image and --container provided together, --container takes precedence.
-	image Optional[string],
 	// Container to use for the runner. If --image and --container provided together, --container takes precedence.
 	container Optional[*Container],
 	// The directory containing the repository source. If source is provided, rest of the options are ignored.
@@ -57,12 +55,11 @@ func (r *Runner) Container(
 	}
 
 	var (
-		id       = uuid.New().String()
-		imageVal = image.GetOr("ghcr.io/catthehacker/ubuntu:act-latest")
-		ctr      = container.GetOr(dag.Container().From(imageVal))
-		info     = getRepoInfo(source, repo, branch, tag)
-		path     = getRunnerCacheVolumeMountPath(id)
-		cache    = getRunnerCacheVolume(id)
+		id    = uuid.New().String()
+		ctr   = container.GetOr(dag.Container().From("ghcr.io/catthehacker/ubuntu:act-latest"))
+		info  = getRepoInfo(source, repo, branch, tag)
+		path  = getRunnerCacheVolumeMountPath(id)
+		cache = getRunnerCacheVolume(id)
 	)
 
 	// configure internal components


### PR DESCRIPTION
Dagger cli already converts string type to a container. No need to use a separate flag for it